### PR TITLE
Fix pending session state and ACP content handling

### DIFF
--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -37,10 +37,31 @@ function isUserMessage(text: string): boolean {
   return text.startsWith("> ");
 }
 
+/**
+ * Normalize ACP content format to protocol ToolCallContent format.
+ * ACP sends: {type: "content", content: {type: "text", text: "..."}}
+ * Protocol expects: {type: "text", text: "..."}
+ */
+function normalizeContent(content?: ToolCallContent[]): ToolCallContent[] | undefined {
+  if (!content?.length) return content;
+  return content.map((item) => {
+    if (item.type === "text" || item.type === "diff") return item;
+    // Handle ACP wrapped format: {type: "content", content: {type: "text", text: "..."}}
+    const wrapped = item as unknown as { type: string; content?: ToolCallContent };
+    if (wrapped.content && typeof wrapped.content === "object") {
+      return wrapped.content;
+    }
+    return item;
+  });
+}
+
 function mergeToolCall(
   existing: RenderableToolCall | undefined,
   update: Extract<SessionUpdate, { sessionUpdate: "tool_call" | "tool_call_update" }>,
 ): RenderableToolCall {
+  // Pick up content from raw data (ACP sends content on tool_call too)
+  const rawContent = normalizeContent((update as unknown as { content?: ToolCallContent[] }).content);
+
   if (update.sessionUpdate === "tool_call") {
     return {
       toolCallId: update.toolCallId,
@@ -48,7 +69,7 @@ function mergeToolCall(
       kind: update.kind,
       status: update.status,
       locations: update.locations,
-      content: existing?.content,
+      content: rawContent ?? existing?.content,
     };
   }
 
@@ -58,7 +79,7 @@ function mergeToolCall(
     kind: existing?.kind,
     status: update.status,
     locations: existing?.locations,
-    content: update.content ?? existing?.content,
+    content: rawContent ?? existing?.content,
   };
 }
 

--- a/packages/client/src/components/chat/SessionView.tsx
+++ b/packages/client/src/components/chat/SessionView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { SessionInfo, SessionUpdate } from "@matrix/protocol";
+import type { HistoryEntry, SessionInfo, SessionUpdate } from "@matrix/protocol";
 import type { MatrixSession, PromptCallbacks } from "@matrix/sdk";
 import { nanoid } from "nanoid";
 import { useMatrixClient } from "@/hooks/useMatrixClient";
@@ -65,20 +65,37 @@ export function SessionView({ sessionInfo, onSessionInfoChange }: SessionViewPro
   }, []);
 
   const replaceEventsFromHistory = useCallback(
-    (history: Array<{ id: string; role: "user" | "agent"; content: string; timestamp: string }>) => {
+    (history: HistoryEntry[]) => {
       setEvents(
-        history.map((entry) => ({
-          id: entry.id,
-          type: "message",
-          data: {
-            sessionUpdate: "agent_message_chunk",
-            content: {
-              type: "text",
-              text: entry.role === "user" ? `> ${entry.content}` : entry.content,
-            },
-          },
-          timestamp: Date.parse(entry.timestamp) || Date.now(),
-        })),
+        history
+          .filter((entry) => entry.type !== "completed")
+          .map((entry) => {
+            const timestamp = Date.parse(entry.timestamp) || Date.now();
+
+            // Structured events: reconstruct from metadata
+            if (entry.type !== "text" && entry.metadata) {
+              return {
+                id: entry.id,
+                type: entry.type,
+                data: entry.metadata as unknown as SessionUpdate,
+                timestamp,
+              };
+            }
+
+            // Text messages
+            return {
+              id: entry.id,
+              type: "message",
+              data: {
+                sessionUpdate: "agent_message_chunk" as const,
+                content: {
+                  type: "text" as const,
+                  text: entry.role === "user" ? `> ${entry.content}` : entry.content,
+                },
+              },
+              timestamp,
+            };
+          }),
       );
     },
     [],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,8 +6,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch --env-file=../../.env.local --env-file=.env src/index.ts",
-    "start": "node --env-file=../../.env.local --env-file=.env dist/index.js",
+    "dev": "tsx watch --env-file=../../.env --env-file=../../.env.local src/index.ts",
+    "start": "node --env-file=../../.env --env-file=../../.env.local dist/index.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/server/src/acp-bridge/index.ts
+++ b/packages/server/src/acp-bridge/index.ts
@@ -1,4 +1,10 @@
+import { appendFileSync } from "node:fs";
 import type { ChildProcess } from "node:child_process";
+
+function debugLog(msg: string) {
+  const line = `[${new Date().toISOString()}] ${msg}\n`;
+  appendFileSync("/tmp/matrix-bridge.log", line);
+}
 import type { AgentCapabilities, SessionUpdate, SessionId } from "@matrix/protocol";
 import { encodeJsonRpc, parseJsonRpcMessages, type JsonRpcMessage } from "./jsonrpc.js";
 
@@ -46,7 +52,9 @@ export class AcpBridge {
     private handlers: BridgeEventHandler,
   ) {
     this.process.stdout!.on("data", (data: Buffer) => {
-      this.buffer += data.toString();
+      const chunk = data.toString();
+      debugLog(`stdout chunk (${chunk.length} bytes): ${chunk.slice(0, 300)}`);
+      this.buffer += chunk;
       this.processBuffer();
     });
 
@@ -90,7 +98,7 @@ export class AcpBridge {
       protocolVersion: 1,
       clientCapabilities: {
         fs: { readTextFile: true, writeTextFile: true },
-        terminal: true,
+        terminal: false,
       },
       clientInfo,
     }) as InitializeResult;
@@ -173,6 +181,7 @@ export class AcpBridge {
 
   private write(message: JsonRpcMessage): void {
     const encoded = encodeJsonRpc(message);
+    debugLog(`send: ${JSON.stringify(message).slice(0, 500)}`);
     this.process.stdin!.write(encoded);
   }
 
@@ -186,6 +195,7 @@ export class AcpBridge {
   }
 
   private handleMessage(msg: JsonRpcMessage): void {
+    debugLog(`recv: ${JSON.stringify(msg).slice(0, 500)}`);
     if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
       const pending = this.pendingRequests.get(msg.id);
       if (pending) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -66,6 +66,7 @@ function emitSessionError(sessionId: string, code: string, message: string): voi
 }
 
 async function handlePrompt(sessionId: string, prompt: Array<{ type: string; text: string }>) {
+  console.log(`[session ${sessionId}] handlePrompt:`, JSON.stringify(prompt).slice(0, 200));
   const session = store.getSession(sessionId);
   if (!session) {
     emitSessionError(sessionId, "session_not_found", "Session not found");
@@ -127,6 +128,7 @@ async function createBridge(
 
   const bridge = new AcpBridge(handle.process, {
     onSessionUpdate(sid, update) {
+      console.log(`[session ${sessionId}] update: ${update.sessionUpdate}`, JSON.stringify(update).slice(0, 200));
       store.touchSession(sessionId);
       connectionManager.broadcastToSession(sessionId, {
         type: "session:update",
@@ -159,6 +161,7 @@ async function createBridge(
       }
     },
     onPermissionRequest(sid, request) {
+      console.log(`[session ${sessionId}] permission_request:`, JSON.stringify(request.params).slice(0, 300));
       store.touchSession(sessionId);
       const permUpdate = {
         sessionUpdate: "permission_request" as const,
@@ -183,6 +186,7 @@ async function createBridge(
       });
     },
     onClose() {
+      console.log(`[session ${sessionId}] agent process closed`);
       console.log(`[session ${sessionId}] Agent process closed`);
       // Flush any buffered agent message chunks before closing
       flushAgentMessageBuffer(sessionId);
@@ -209,15 +213,18 @@ sessionManager.setBridgeFactory(createBridge);
 const app = new Hono();
 
 // CORS for web client — restrict to known origins
-app.use("/*", cors({
-  origin: [
-    "http://localhost:5173",  // Vite dev server
-    "http://localhost:1420",  // Tauri dev
-    "tauri://localhost",      // Tauri production
-  ],
-}));
+const corsOrigins = [
+  "http://localhost:5173",  // Vite dev server
+  "http://localhost:1420",  // Tauri dev
+  "tauri://localhost",      // Tauri production
+];
+if (process.env.CLIENT_PORT) {
+  corsOrigins.push(`http://localhost:${process.env.CLIENT_PORT}`);
+}
+app.use("/*", cors({ origin: corsOrigins }));
 
 // Auth middleware for REST (WebSocket handles auth separately)
+app.use("/agents", authMiddleware(serverToken));
 app.use("/agents/*", authMiddleware(serverToken));
 app.use("/sessions", authMiddleware(serverToken));
 app.use("/sessions/*", authMiddleware(serverToken));

--- a/packages/server/src/store/index.ts
+++ b/packages/server/src/store/index.ts
@@ -261,7 +261,14 @@ export class Store {
     type: HistoryEntryType,
     data: Record<string, unknown>,
   ): void {
-    const content = data.content != null ? String(data.content) : "";
+    let content = "";
+    if (data.content == null) {
+      content = "";
+    } else if (typeof data.content === "string") {
+      content = data.content;
+    } else {
+      content = JSON.stringify(data.content);
+    }
     this.appendHistory(sessionId, "agent", content, type, data);
   }
 


### PR DESCRIPTION
## Summary
- Fix ACP content normalization so tool call results render correctly (ACP sends wrapped `{type: "content", content: {...}}` format)
- Reconstruct structured history entries (tool calls, permissions) when restoring sessions, instead of flattening everything to text
- Fix server env file loading order, non-string content serialization, dynamic CORS origins, and `/agents` auth
- Disable terminal capability in ACP bridge and add debug logging for message flow

## Test plan
- [x] All 189 tests pass (sdk: 54, server: 127, client: 8)
- [ ] Verify tool call rendering in restored sessions shows structured content
- [ ] Verify ACP bridge content normalization with live agent

Generated with [Claude Code](https://claude.com/claude-code)