### PR TITLE
fix: altstore source with correct IPA

### DIFF
--- a/altstore-source.json
+++ b/altstore-source.json
@@ -14,10 +14,10 @@
       "tintColor": "#7C3AED",
       "versions": [
         {
-          "version": "0.1.4",
+          "version": "0.1.0",
           "date": "2026-03-16",
           "downloadURL": "https://github.com/broven/matrix/releases/download/v0.1.4/Matrix_v0.1.4.ipa",
-          "size": 0,
+          "size": 3693761,
           "minOSVersion": "16.0"
         },
         {


### PR DESCRIPTION
Locally built IPA with embedded frontend