### PR TITLE
fix: sidecar crashes silently due to non-writable db path

### DIFF
--- a/packages/client/src-tauri/src/lib.rs
+++ b/packages/client/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ pub fn run() {
                 let web_dir = resource_dir.join("web");
 
                 let shell = app.shell();
-                let (mut _rx, child) = shell
+                let (mut rx, child) = shell
                     .sidecar("matrix-server")
                     .expect("failed to create sidecar command")
                     .args([
@@ -43,6 +43,29 @@ pub fn run() {
                     .expect("failed to spawn matrix-server sidecar");
 
                 app.manage(SidecarState(std::sync::Mutex::new(Some(child))));
+
+                // Log sidecar output for debugging
+                tauri::async_runtime::spawn(async move {
+                    use tauri_plugin_shell::process::CommandEvent;
+                    while let Some(event) = rx.recv().await {
+                        match event {
+                            CommandEvent::Stdout(line) => {
+                                eprintln!("[matrix-server] {}", String::from_utf8_lossy(&line));
+                            }
+                            CommandEvent::Stderr(line) => {
+                                eprintln!("[matrix-server:err] {}", String::from_utf8_lossy(&line));
+                            }
+                            CommandEvent::Terminated(payload) => {
+                                eprintln!(
+                                    "[matrix-server] terminated code={:?} signal={:?}",
+                                    payload.code, payload.signal
+                                );
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                });
 
                 // Inject a redirect script into the webview to navigate to sidecar URL
                 let main_window = app.get_webview_window("main").unwrap();

--- a/packages/client/src-tauri/tauri.conf.json
+++ b/packages/client/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeBuildCommand": "pnpm build",
     "beforeDevCommand": "pnpm dev",
-    "devUrl": "http://localhost:18914",
+    "devUrl": "http://localhost:15909",
     "frontendDist": "../dist"
   },
   "app": {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,4 +1,7 @@
 import type { AgentConfig } from "@matrix/protocol";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 
 export interface ServerConfig {
   port: number;
@@ -22,13 +25,20 @@ function parseArgs(): Record<string, string> {
   return args;
 }
 
+function getDefaultDbPath(localMode: boolean): string {
+  if (!localMode) return "./matrix.db";
+  const dataDir = path.join(homedir(), "Library", "Application Support", "com.matrix.client");
+  mkdirSync(dataDir, { recursive: true });
+  return path.join(dataDir, "matrix.db");
+}
+
 export function loadConfig(): ServerConfig {
   const args = parseArgs();
   const localMode = args.local === "true" || process.env.MATRIX_LOCAL === "true" || false;
   return {
     port: parseInt(args.port || process.env.MATRIX_PORT || "8080", 10),
     host: localMode ? "127.0.0.1" : (args.host || process.env.MATRIX_HOST || "0.0.0.0"),
-    dbPath: args.db || process.env.MATRIX_DB_PATH || "./matrix.db",
+    dbPath: args.db || process.env.MATRIX_DB_PATH || getDefaultDbPath(localMode),
     webDir: args.web || process.env.MATRIX_WEB_DIR || null,
     localMode,
     agents: [


### PR DESCRIPTION
## Summary
- **Root cause**: Tauri spawns the `matrix-server` sidecar in a non-writable working directory (e.g., `/`), causing `SQLITE_CANTOPEN` when trying to create `./matrix.db`. The crash was invisible because sidecar stdout/stderr was discarded.
- In `localMode`, the database now defaults to `~/Library/Application Support/com.matrix.client/matrix.db`
- Sidecar output is now logged via `eprintln!` so future crashes are visible in logs

## Test plan
- [x] Reproduced: ran old binary from `/` with `--local true` → `SQLITE_CANTOPEN`
- [x] Verified: rebuilt server with fix, ran from `/` with `--local true` → starts successfully, db created at correct path
- [x] SDK tests pass (54/54)
- [ ] Build new release and verify desktop app connects without reconnecting loop

Generated with [Claude Code](https://claude.com/claude-code)