### PR TITLE
feat: redesign chat UI with warm editorial aesthetic

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&family=Newsreader:opsz,wght@6..72,400;6..72,500;6..72,600&family=Noto+Sans+SC:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
     <title>Matrix</title>

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -1,9 +1,12 @@
+import { useState } from "react";
 import type { SessionUpdate, ToolCallContent, ToolCallLocation, ToolCallStatus, ToolKind } from "@matrix/protocol";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { ChevronRight, Copy, Check, RotateCcw } from "lucide-react";
 import { PlanView } from "@/components/PlanView";
 import { PermissionCard } from "@/components/PermissionCard";
 import { ToolCallCard } from "@/components/ToolCallCard";
+import { cn } from "@/lib/utils";
 
 export interface SessionEvent {
   id: string;
@@ -28,7 +31,7 @@ interface RenderableToolCall {
 }
 
 type RenderItem =
-  | { key: string; kind: "message"; text: string }
+  | { key: string; kind: "message"; text: string; timestamp?: number }
   | { key: string; kind: "tool_call"; toolCall: RenderableToolCall }
   | { key: string; kind: "permission_request"; data: Extract<SessionUpdate, { sessionUpdate: "permission_request" }> }
   | { key: string; kind: "plan"; data: Extract<SessionUpdate, { sessionUpdate: "plan" }> };
@@ -127,7 +130,7 @@ export function buildRenderItems(events: SessionEvent[]): RenderItem[] {
           break;
         }
 
-        renderItems.push({ key: event.id, kind: "message", text });
+        renderItems.push({ key: event.id, kind: "message", text, timestamp: event.timestamp });
         break;
       }
       case "permission_request":
@@ -144,20 +147,121 @@ export function buildRenderItems(events: SessionEvent[]): RenderItem[] {
   return renderItems;
 }
 
+function formatElapsed(timestamp?: number) {
+  if (!timestamp) return null;
+  const elapsed = Math.round((Date.now() - timestamp) / 1000);
+  if (elapsed < 60) return `${elapsed}s`;
+  return `${Math.floor(elapsed / 60)}m`;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:text-foreground"
+      aria-label="Copy message"
+    >
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+    </button>
+  );
+}
+
+/** Group consecutive tool calls into a collapsible cluster */
+function ToolCallCluster({ items, allItems }: { items: RenderItem[]; allItems: RenderItem[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const toolCalls = items.filter((i) => i.kind === "tool_call");
+  const messages = items.filter((i) => i.kind === "message");
+
+  const summary = [
+    toolCalls.length > 0 && `${toolCalls.length} tool call${toolCalls.length > 1 ? "s" : ""}`,
+    messages.length > 0 && `${messages.length} message${messages.length > 1 ? "s" : ""}`,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <div className="animate-message-in">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="group flex items-center gap-1.5 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronRight
+          className={cn(
+            "size-4 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        <span>{summary}</span>
+        {!expanded && (
+          <span className="font-mono text-xs text-muted-foreground/50">&gt;_</span>
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-2 space-y-3 border-l-2 border-border pl-4">
+          {items.map((item) => {
+            if (item.kind === "tool_call") {
+              return <ToolCallCard key={item.key} toolCall={item.toolCall} />;
+            }
+            return null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function MessageList({ events, onApprove, onReject }: Props) {
   const renderItems = buildRenderItems(events);
 
+  // Group consecutive tool calls together
+  const groupedItems: Array<{ type: "single"; item: RenderItem } | { type: "cluster"; items: RenderItem[] }> = [];
+
+  for (const item of renderItems) {
+    if (item.kind === "tool_call") {
+      const lastGroup = groupedItems.at(-1);
+      if (lastGroup?.type === "cluster") {
+        lastGroup.items.push(item);
+      } else {
+        groupedItems.push({ type: "cluster", items: [item] });
+      }
+    } else {
+      groupedItems.push({ type: "single", item });
+    }
+  }
+
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-5 md:px-6 md:py-6">
-      {renderItems.map((item) => {
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 px-4 py-6 md:px-6 md:py-8">
+      {groupedItems.map((group, index) => {
+        if (group.type === "cluster") {
+          return (
+            <ToolCallCluster
+              key={group.items[0].key}
+              items={group.items}
+              allItems={renderItems}
+            />
+          );
+        }
+
+        const item = group.item;
+
         switch (item.kind) {
           case "message": {
             const isOwnMessage = isUserMessage(item.text);
 
             if (isOwnMessage) {
               return (
-                <div key={item.key} className="flex justify-end">
-                  <div className="max-w-[85%] rounded-3xl rounded-br-sm bg-primary/10 px-4 py-3 text-sm leading-6 text-foreground shadow-sm dark:bg-primary/20">
+                <div key={item.key} className="flex justify-end animate-message-in">
+                  <div className="max-w-[80%] rounded-[1.25rem] rounded-br-md bg-user-bubble px-4 py-2.5 text-[0.9375rem] leading-relaxed text-user-bubble-foreground">
                     <p className="whitespace-pre-wrap">{item.text.slice(2)}</p>
                   </div>
                 </div>
@@ -165,15 +269,21 @@ export function MessageList({ events, onApprove, onReject }: Props) {
             }
 
             return (
-              <div key={item.key} className="flex justify-start">
-                <div className="markdown-content max-w-[90%] rounded-3xl rounded-bl-sm border bg-card px-4 py-3 text-sm leading-6 shadow-sm md:max-w-[82%]">
+              <div key={item.key} className="group/msg animate-message-in">
+                <div className="markdown-content max-w-none text-[0.9375rem] leading-[1.7]">
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{item.text}</ReactMarkdown>
+                </div>
+                <div className="mt-1.5 flex items-center gap-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
+                  {item.timestamp && (
+                    <span className="mr-1 text-xs text-muted-foreground/50">
+                      {formatElapsed(item.timestamp)}
+                    </span>
+                  )}
+                  <CopyButton text={item.text} />
                 </div>
               </div>
             );
           }
-          case "tool_call":
-            return <ToolCallCard key={item.key} toolCall={item.toolCall} />;
           case "permission_request":
             return (
               <PermissionCard

--- a/packages/client/src/components/PlanView.tsx
+++ b/packages/client/src/components/PlanView.tsx
@@ -1,6 +1,5 @@
 import type { PlanEntry } from "@matrix/protocol";
 import { CheckCircle2, Circle, LoaderCircle } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -15,27 +14,25 @@ function getIcon(status: PlanEntry["status"]) {
 
 export function PlanView({ plan }: Props) {
   return (
-    <Card className="gap-4">
-      <CardHeader className="pb-0">
-        <CardTitle className="text-base">Plan</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
+    <div className="animate-message-in rounded-xl border border-border/50 bg-card/50 px-4 py-3.5">
+      <p className="mb-3 text-xs font-medium uppercase tracking-widest text-muted-foreground">Plan</p>
+      <div className="space-y-2.5">
         {plan.entries.map((entry, index) => {
           const Icon = getIcon(entry.status);
 
           return (
-            <div key={`${entry.content}-${index}`} className="flex items-start gap-3">
+            <div key={`${entry.content}-${index}`} className="flex items-start gap-2.5">
               <Icon
                 className={cn(
                   "mt-0.5 size-4 shrink-0",
                   entry.status === "completed" && "text-success",
                   entry.status === "in_progress" && "animate-spin text-primary",
-                  entry.status === "pending" && "text-muted-foreground",
+                  entry.status === "pending" && "text-muted-foreground/40",
                 )}
               />
               <p
                 className={cn(
-                  "text-sm leading-6",
+                  "text-sm leading-relaxed",
                   entry.status === "completed" && "text-foreground",
                   entry.status === "in_progress" && "text-foreground",
                   entry.status === "pending" && "text-muted-foreground",
@@ -46,7 +43,7 @@ export function PlanView({ plan }: Props) {
             </div>
           );
         })}
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/packages/client/src/components/PromptInput.tsx
+++ b/packages/client/src/components/PromptInput.tsx
@@ -1,15 +1,23 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
-import { ArrowUp } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ArrowUp, Plus } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 interface Props {
   onSend: (text: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  isProcessing?: boolean;
+  agentName?: string;
 }
 
-export function PromptInput({ onSend, disabled, placeholder = "Message the active session..." }: Props) {
+export function PromptInput({
+  onSend,
+  disabled,
+  placeholder = "Ask to make changes, @mention files, run /commands",
+  isProcessing,
+  agentName,
+}: Props) {
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -18,7 +26,7 @@ export function PromptInput({ onSend, disabled, placeholder = "Message the activ
     if (!textarea) return;
 
     textarea.style.height = "0px";
-    textarea.style.height = `${Math.min(textarea.scrollHeight, 240)}px`;
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
   }, [text]);
 
   const handleSend = () => {
@@ -35,27 +43,58 @@ export function PromptInput({ onSend, disabled, placeholder = "Message the activ
   };
 
   return (
-    <div className="border-t border-border bg-background/95 px-4 py-4 backdrop-blur md:px-6">
-      <div className="mx-auto flex max-w-5xl items-end gap-3">
-        <Textarea
-          ref={textareaRef}
-          value={text}
-          onChange={(event) => setText(event.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          disabled={disabled}
-          rows={1}
-          className="max-h-60 min-h-12 resize-none rounded-2xl border-border/80 bg-card px-4 py-3 shadow-sm"
-        />
-        <Button
-          onClick={handleSend}
-          disabled={disabled || !text.trim()}
-          size="icon-lg"
-          className="rounded-2xl"
+    <div className="px-4 pb-4 pt-2 md:px-6">
+      <div className="mx-auto max-w-3xl">
+        <div
+          className={cn(
+            "overflow-hidden rounded-[1.25rem] border border-border/60 bg-card shadow-sm transition-shadow",
+            "focus-within:border-border focus-within:shadow-md",
+          )}
         >
-          <ArrowUp className="size-5" />
-          <span className="sr-only">Send prompt</span>
-        </Button>
+          <Textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            disabled={disabled}
+            rows={1}
+            className="max-h-[200px] min-h-[52px] resize-none border-0 bg-transparent px-4 py-3.5 text-[0.9375rem] leading-relaxed placeholder:text-muted-foreground/50 focus-visible:ring-0 focus-visible:ring-offset-0"
+          />
+          <div className="flex items-center justify-between px-3 pb-2.5 pt-0">
+            <div className="flex items-center gap-2">
+              {agentName && (
+                <span className="flex items-center gap-1.5 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground">
+                  <span className="size-1.5 rounded-full bg-primary" />
+                  {agentName}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                className="flex size-8 items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:bg-secondary hover:text-foreground"
+                aria-label="Attach"
+              >
+                <Plus className="size-4.5" />
+              </button>
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={disabled || !text.trim()}
+                className={cn(
+                  "flex size-8 items-center justify-center rounded-full transition-all",
+                  text.trim() && !disabled
+                    ? "bg-foreground text-background hover:opacity-80"
+                    : "bg-muted text-muted-foreground/40",
+                )}
+                aria-label="Send message"
+              >
+                <ArrowUp className="size-4" strokeWidth={2.5} />
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/client/src/components/ToolCallCard.tsx
+++ b/packages/client/src/components/ToolCallCard.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 import type { ToolCallContent, ToolCallLocation, ToolCallStatus } from "@matrix/protocol";
-import { ChevronDown, WandSparkles } from "lucide-react";
+import { ChevronRight, Terminal } from "lucide-react";
 import { ToolContentList } from "@/components/ToolContent";
-import { Badge } from "@/components/ui/badge";
-import { Card } from "@/components/ui/card";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -18,57 +15,55 @@ interface Props {
   };
 }
 
-const statusVariant: Record<ToolCallStatus, "secondary" | "default" | "destructive" | "outline"> = {
-  pending: "outline",
-  running: "secondary",
-  completed: "default",
-  error: "destructive",
+const statusColors: Record<ToolCallStatus, string> = {
+  pending: "text-muted-foreground",
+  running: "text-primary",
+  completed: "text-success",
+  error: "text-destructive",
 };
 
 export function ToolCallCard({ toolCall }: Props) {
-  const [open, setOpen] = useState(Boolean(toolCall.content?.length));
+  const [open, setOpen] = useState(false);
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
-      <Card className="gap-0 overflow-hidden py-0">
-        <CollapsibleTrigger className="w-full text-left">
-          <div className="flex items-center justify-between gap-3 px-4 py-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                <WandSparkles className="size-4" />
-              </div>
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant={statusVariant[toolCall.status]}>
-                    {toolCall.status}
-                  </Badge>
-                  <span className="truncate text-sm font-medium">
-                    {toolCall.kind ?? "tool"}: {toolCall.title ?? toolCall.toolCallId}
-                  </span>
-                </div>
-                {toolCall.locations?.length ? (
-                  <div className="mt-1 flex flex-wrap gap-2">
-                    {toolCall.locations.map((location) => (
-                      <code
-                        key={location.path}
-                        className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-                      >
-                        {location.path}
-                      </code>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            </div>
-            <ChevronDown
-              className={cn("size-4 shrink-0 transition-transform", open && "rotate-180")}
-            />
+    <div className="rounded-xl border border-border/50 bg-card/50">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors hover:bg-accent/30"
+      >
+        <Terminal className={cn("size-4 shrink-0", statusColors[toolCall.status])} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium">
+              {toolCall.title ?? toolCall.toolCallId}
+            </span>
+            <span className={cn("text-xs", statusColors[toolCall.status])}>
+              {toolCall.status}
+            </span>
           </div>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="border-t border-border px-4 py-4">
+          {toolCall.locations?.length ? (
+            <div className="mt-0.5 flex flex-wrap gap-1.5">
+              {toolCall.locations.map((location) => (
+                <code
+                  key={location.path}
+                  className="rounded bg-muted/60 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                >
+                  {location.path}
+                </code>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <ChevronRight
+          className={cn("size-3.5 shrink-0 text-muted-foreground/50 transition-transform", open && "rotate-90")}
+        />
+      </button>
+      {open && toolCall.content?.length ? (
+        <div className="border-t border-border/40 px-3.5 py-3">
           <ToolContentList content={toolCall.content} />
-        </CollapsibleContent>
-      </Card>
-    </Collapsible>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/packages/client/src/components/chat/SessionView.tsx
+++ b/packages/client/src/components/chat/SessionView.tsx
@@ -23,7 +23,7 @@ function isTerminalSessionError(code: string) {
 function getInputPlaceholder(status: ViewStatus) {
   switch (status) {
     case "active":
-      return "Message the active session...";
+      return "Ask to make changes, @mention files, run /commands";
     case "suspended":
       return "Send a message to resume this session...";
     case "restoring":
@@ -248,6 +248,8 @@ export function SessionView({ sessionInfo, onSessionInfoChange }: SessionViewPro
         onSend={handleSend}
         disabled={inputDisabled}
         placeholder={getInputPlaceholder(viewStatus)}
+        isProcessing={isProcessing}
+        agentName={sessionInfo.agentId}
       />
     </div>
   );

--- a/packages/client/src/components/chat/StatusBar.tsx
+++ b/packages/client/src/components/chat/StatusBar.tsx
@@ -1,6 +1,5 @@
-import { Loader2, Square } from "lucide-react";
+import { Square } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 
 interface StatusBarProps {
   status: "working" | "idle" | "error" | "suspended" | "closed" | "restoring";
@@ -9,50 +8,53 @@ interface StatusBarProps {
 }
 
 export function StatusBar({ status, message, onCancel }: StatusBarProps) {
+  // Hide when idle
+  if (status === "idle") return null;
+
   return (
-    <div className="border-t border-border bg-background px-4 py-2 md:px-6">
-      <div className="flex items-center gap-3">
+    <div className="px-4 md:px-6">
+      <div className="mx-auto flex max-w-3xl items-center gap-3 py-2">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {status === "working" && (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+            <div className="flex items-center gap-2">
+              <div className="flex gap-0.5">
+                <span className="thinking-dot size-1 rounded-full bg-primary" />
+                <span className="thinking-dot size-1 rounded-full bg-primary" />
+                <span className="thinking-dot size-1 rounded-full bg-primary" />
+              </div>
               <span>Thinking...</span>
-            </>
+            </div>
           )}
           {status === "restoring" && (
-            <span className="text-primary/70">Restoring...</span>
+            <span className="text-primary/70">Restoring session...</span>
           )}
           {status === "error" && (
-            <span className="text-destructive">Error</span>
+            <span className="text-destructive">{message ?? "Error"}</span>
           )}
           {status === "suspended" && (
-            <span className="text-amber-500/70">Suspended</span>
+            <span className="text-amber-500/80">{message ?? "Session suspended"}</span>
           )}
           {status === "closed" && (
-            <span className="text-slate-500/70">Closed</span>
+            <span className="text-muted-foreground/60">{message ?? "Session closed"}</span>
           )}
         </div>
 
         <div className="flex-1" />
 
         {status === "working" && onCancel && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "h-7 gap-1 px-2 text-xs text-muted-foreground",
-              "hover:text-destructive hover:bg-destructive/10",
-            )}
+          <button
+            type="button"
             onClick={onCancel}
+            className={cn(
+              "flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs text-muted-foreground transition-colors",
+              "hover:bg-destructive/10 hover:text-destructive",
+            )}
           >
-            <Square className="h-3 w-3" />
+            <Square className="size-3" />
             Stop
-          </Button>
+          </button>
         )}
       </div>
-      {message ? (
-        <p className="mt-1 text-xs text-muted-foreground">{message}</p>
-      ) : null}
     </div>
   );
 }

--- a/packages/client/src/components/layout/AppLayout.tsx
+++ b/packages/client/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { AgentListItem, SessionInfo } from "@matrix/protocol";
-import { PanelLeftOpen, Plus, Settings } from "lucide-react";
+import { MessageSquarePlus } from "lucide-react";
 import { useMatrixClient } from "@/hooks/useMatrixClient";
 import { SessionView } from "@/components/chat/SessionView";
 import { MobileHeader } from "@/components/layout/MobileHeader";
@@ -8,6 +8,7 @@ import { Sidebar } from "@/components/layout/Sidebar";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Settings } from "lucide-react";
 
 const SESSION_STATUS_ORDER: Record<SessionInfo["status"], number> = {
   active: 0,
@@ -161,7 +162,7 @@ export function AppLayout() {
 
   return (
     <div className="flex h-screen overflow-hidden bg-background">
-      <aside className="hidden h-full w-[280px] shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col">
+      <aside className="hidden h-full w-[260px] shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col">
         <Sidebar
           agents={agents}
           sessions={sortedSessions}
@@ -175,17 +176,17 @@ export function AppLayout() {
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-start gap-2"
+            className="w-full justify-start gap-2 rounded-lg text-xs"
             onClick={() => setShowSettings(true)}
           >
-            <Settings className="size-4" />
+            <Settings className="size-3.5" />
             Settings
           </Button>
         </div>
       </aside>
 
       <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
-        <SheetContent side="left" className="w-[86vw] max-w-[320px] border-sidebar-border bg-sidebar p-0">
+        <SheetContent side="left" className="w-[86vw] max-w-[300px] border-sidebar-border bg-sidebar p-0">
           <Sidebar
             agents={agents}
             sessions={sortedSessions}
@@ -219,22 +220,22 @@ export function AppLayout() {
           />
         ) : (
           <div className="flex flex-1 items-center justify-center p-6">
-            <div className="max-w-md space-y-4 rounded-[1.75rem] border border-dashed border-border bg-card/70 p-8 text-center shadow-sm">
-              <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                <PanelLeftOpen className="size-6" />
+            <div className="max-w-sm space-y-5 text-center">
+              <div className="mx-auto flex size-12 items-center justify-center rounded-2xl bg-accent text-muted-foreground">
+                <MessageSquarePlus className="size-5" />
               </div>
               <div className="space-y-2">
-                <h2 className="text-2xl font-semibold tracking-tight">No session selected</h2>
+                <h2 className="text-xl font-semibold tracking-tight">No session selected</h2>
                 <p className="text-sm leading-6 text-muted-foreground">
-                  Pick a session from the sidebar or create a new one to open the chat view.
+                  Pick a session from the sidebar or create a new one.
                 </p>
               </div>
               <Button
-                className="w-full sm:w-auto"
+                className="rounded-xl"
                 onClick={() => setMobileSidebarOpen(true)}
                 variant="outline"
+                size="sm"
               >
-                <Plus className="size-4" />
                 Open Sessions
               </Button>
             </div>

--- a/packages/client/src/components/layout/ChatHeader.tsx
+++ b/packages/client/src/components/layout/ChatHeader.tsx
@@ -1,6 +1,5 @@
 import type { SessionInfo } from "@matrix/protocol";
-import { FolderRoot, Radio } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 interface ChatHeaderProps {
   session: SessionInfo;
@@ -9,49 +8,38 @@ interface ChatHeaderProps {
   statusMessage?: string | null;
 }
 
-function getStatusBadge(sessionStatus: SessionInfo["status"]) {
-  switch (sessionStatus) {
-    case "active":
-      return { variant: "secondary" as const, label: "Active" };
-    case "restoring":
-      return { variant: "default" as const, label: "Restoring" };
-    case "suspended":
-      return { variant: "outline" as const, label: "Suspended" };
-    case "closed":
-      return { variant: "outline" as const, label: "Closed" };
-  }
-}
-
-export function ChatHeader({ session, isProcessing, sessionStatus, statusMessage }: ChatHeaderProps) {
-  const sessionBadge = getStatusBadge(sessionStatus);
-
+export function ChatHeader({ session, isProcessing, sessionStatus }: ChatHeaderProps) {
   return (
-    <header className="hidden border-b border-border bg-background/90 px-6 py-4 backdrop-blur md:flex md:items-center md:justify-between">
-      <div className="space-y-1">
+    <header className="hidden items-center justify-between border-b border-border/50 bg-background px-6 py-3 md:flex">
+      <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
-          <Badge variant="outline" className="rounded-full px-2.5 py-0.5">
-            Session
-          </Badge>
-          <Badge variant={sessionBadge.variant} className="rounded-full px-2.5 py-0.5">
-            {sessionBadge.label}
-          </Badge>
-          <h1 className="text-lg font-semibold tracking-tight">{session.agentId}</h1>
+          <div
+            className={cn(
+              "size-2 rounded-full",
+              sessionStatus === "active" && "bg-success",
+              sessionStatus === "restoring" && "bg-primary animate-pulse",
+              sessionStatus === "suspended" && "bg-amber-400",
+              sessionStatus === "closed" && "bg-muted-foreground/40",
+            )}
+          />
+          <h1 className="text-sm font-medium">{session.agentId}</h1>
         </div>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <FolderRoot className="size-4" />
-          <span className="truncate">{session.cwd}</span>
-        </div>
-        {statusMessage ? (
-          <p className="max-w-2xl text-xs text-muted-foreground">{statusMessage}</p>
-        ) : null}
+        <span className="text-xs text-muted-foreground">{session.cwd}</span>
       </div>
-      <Badge
-        variant={isProcessing || sessionStatus === "restoring" ? "default" : "secondary"}
-        className="rounded-full px-3 py-1"
-      >
-        <Radio className="mr-1 size-3.5" />
-        {sessionStatus === "restoring" ? "Restoring" : isProcessing ? "Working" : "Idle"}
-      </Badge>
+      <div className="flex items-center gap-3">
+        {(isProcessing || sessionStatus === "restoring") && (
+          <div className="flex items-center gap-1.5">
+            <div className="flex gap-0.5">
+              <span className="thinking-dot size-1 rounded-full bg-primary" />
+              <span className="thinking-dot size-1 rounded-full bg-primary" />
+              <span className="thinking-dot size-1 rounded-full bg-primary" />
+            </div>
+            <span className="text-xs text-muted-foreground">
+              {sessionStatus === "restoring" ? "Restoring" : "Thinking"}
+            </span>
+          </div>
+        )}
+      </div>
     </header>
   );
 }

--- a/packages/client/src/components/layout/MobileHeader.tsx
+++ b/packages/client/src/components/layout/MobileHeader.tsx
@@ -9,18 +9,15 @@ interface MobileHeaderProps {
 
 export function MobileHeader({ selectedSession, onOpenSidebar }: MobileHeaderProps) {
   return (
-    <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3 md:hidden">
+    <header className="flex items-center justify-between gap-3 border-b border-border/50 px-4 py-2.5 md:hidden">
       <div className="flex min-w-0 items-center gap-3">
-        <Button size="icon-sm" variant="ghost" onClick={onOpenSidebar}>
+        <Button size="icon-sm" variant="ghost" onClick={onOpenSidebar} className="rounded-lg">
           <Menu className="size-5" />
           <span className="sr-only">Open sessions</span>
         </Button>
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold">
+          <p className="truncate text-sm font-medium">
             {selectedSession?.agentId ?? "Sessions"}
-          </p>
-          <p className="truncate text-xs text-muted-foreground">
-            {selectedSession?.cwd ?? "Choose a session from the drawer"}
           </p>
         </div>
       </div>

--- a/packages/client/src/components/layout/SessionItem.tsx
+++ b/packages/client/src/components/layout/SessionItem.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { SessionInfo } from "@matrix/protocol";
-import { Clock3, X } from "lucide-react";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface SessionItemProps {
@@ -27,37 +27,20 @@ function formatRelativeTime(value: string) {
   return `${diffDays}d ago`;
 }
 
-function getSessionStatusMeta(status: SessionInfo["status"]) {
+function getStatusColor(status: SessionInfo["status"]) {
   switch (status) {
     case "active":
-      return {
-        label: "Active",
-        indicatorClassName:
-          "bg-success shadow-[0_0_0_4px_color-mix(in_oklch,var(--success)_18%,transparent)]",
-      };
+      return "bg-success";
     case "restoring":
-      return {
-        label: "Restoring",
-        indicatorClassName:
-          "bg-primary shadow-[0_0_0_4px_color-mix(in_oklch,var(--primary)_18%,transparent)]",
-      };
+      return "bg-primary animate-pulse";
     case "suspended":
-      return {
-        label: "Suspended",
-        indicatorClassName:
-          "bg-amber-500 shadow-[0_0_0_4px_color-mix(in_oklch,oklch(76.9%_0.188_70.08)_18%,transparent)]",
-      };
+      return "bg-amber-400";
     case "closed":
-      return {
-        label: "Closed",
-        indicatorClassName:
-          "bg-slate-400 shadow-[0_0_0_4px_color-mix(in_oklch,oklch(70.4%_0.04_256.788)_18%,transparent)]",
-      };
+      return "bg-muted-foreground/30";
   }
 }
 
 export function SessionItem({ session, selected, onSelect, onDelete }: SessionItemProps) {
-  const statusMeta = getSessionStatusMeta(session.status);
   const [confirming, setConfirming] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
@@ -139,20 +122,20 @@ export function SessionItem({ session, selected, onSelect, onDelete }: SessionIt
     return (
       <div
         ref={itemRef}
-        className="flex w-full items-center justify-between rounded-2xl border border-destructive/40 bg-destructive/10 px-4 py-3"
+        className="flex w-full items-center justify-between rounded-xl border border-destructive/30 bg-destructive/8 px-3 py-2.5"
       >
-        <span className="text-sm font-medium">Delete session?</span>
-        <div className="flex gap-2">
+        <span className="text-sm font-medium">Delete?</span>
+        <div className="flex gap-1.5">
           <button
             type="button"
-            className="rounded-lg bg-destructive px-3 py-1 text-xs font-medium text-destructive-foreground transition-colors hover:bg-destructive/90"
+            className="rounded-md bg-destructive px-2.5 py-1 text-xs font-medium text-destructive-foreground transition-colors hover:bg-destructive/90"
             onClick={confirmDelete}
           >
             Yes
           </button>
           <button
             type="button"
-            className="rounded-lg bg-muted px-3 py-1 text-xs font-medium transition-colors hover:bg-muted/80"
+            className="rounded-md bg-muted px-2.5 py-1 text-xs font-medium transition-colors hover:bg-muted/80"
             onClick={cancelDelete}
           >
             No
@@ -166,10 +149,10 @@ export function SessionItem({ session, selected, onSelect, onDelete }: SessionIt
     <>
       <div
         className={cn(
-          "group relative flex w-full flex-col gap-2 rounded-2xl border px-4 py-3 text-left transition-colors",
+          "group relative flex w-full cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors",
           selected
-            ? "border-primary/40 bg-primary/10 shadow-sm"
-            : "border-transparent bg-transparent hover:border-sidebar-border hover:bg-background/75",
+            ? "bg-accent"
+            : "hover:bg-accent/50",
         )}
         role="button"
         tabIndex={0}
@@ -185,55 +168,38 @@ export function SessionItem({ session, selected, onSelect, onDelete }: SessionIt
           }
         }}
       >
-        <span
-          className={cn(
-            "absolute inset-y-3 left-1 w-1 rounded-full transition-colors",
-            selected ? "bg-primary" : "bg-transparent group-hover:bg-border",
-          )}
-        />
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium">{session.agentId}</p>
-            <p className="truncate text-xs text-muted-foreground">{session.cwd}</p>
-          </div>
-          <div className="flex flex-col items-end gap-1">
-            <div className="relative mt-1">
-              <div className={cn("size-2 rounded-full transition-opacity group-hover:opacity-0 group-focus-within:opacity-0", statusMeta.indicatorClassName)} />
-              <div
-                role="button"
-                tabIndex={0}
-                className="absolute inset-0 flex -translate-x-0.5 -translate-y-0.5 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  triggerDelete();
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    triggerDelete();
-                  }
-                }}
-                aria-label="Delete session"
-              >
-                <X className="size-3.5 text-muted-foreground hover:text-destructive" />
-              </div>
-            </div>
-            <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              {statusMeta.label}
-            </span>
-          </div>
+        <div className={cn("size-2 shrink-0 rounded-full", getStatusColor(session.status))} />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium">{session.agentId}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {formatRelativeTime(session.lastActiveAt || session.createdAt)}
+          </p>
         </div>
-        <div className="flex items-center gap-1 text-xs text-muted-foreground">
-          <Clock3 className="size-3" />
-          {formatRelativeTime(session.lastActiveAt || session.createdAt)}
+        <div
+          role="button"
+          tabIndex={0}
+          className="flex size-6 items-center justify-center rounded-md opacity-0 transition-opacity group-hover:opacity-100 hover:bg-destructive/10"
+          onClick={(event) => {
+            event.stopPropagation();
+            triggerDelete();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              event.stopPropagation();
+              triggerDelete();
+            }
+          }}
+          aria-label="Delete session"
+        >
+          <X className="size-3.5 text-muted-foreground hover:text-destructive" />
         </div>
       </div>
 
-      {contextMenu ? (
+      {contextMenu && (
         <div
           ref={contextMenuRef}
-          className="fixed z-50 min-w-[140px] rounded-lg border border-border bg-popover p-1 shadow-md"
+          className="fixed z-50 min-w-[140px] rounded-lg border border-border bg-popover p-1 shadow-lg"
           style={{ left: contextMenu.x, top: contextMenu.y }}
         >
           <button
@@ -245,7 +211,7 @@ export function SessionItem({ session, selected, onSelect, onDelete }: SessionIt
             Delete
           </button>
         </div>
-      ) : null}
+      )}
     </>
   );
 }

--- a/packages/client/src/components/layout/Sidebar.tsx
+++ b/packages/client/src/components/layout/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import type { AgentListItem, ConnectionStatus, SessionInfo } from "@matrix/protocol";
-import { FolderSearch2, Plus, Search, Sparkles } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { Plus, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -11,9 +10,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SessionItem } from "@/components/layout/SessionItem";
+import { cn } from "@/lib/utils";
 
 interface SidebarProps {
   agents: AgentListItem[];
@@ -79,43 +78,48 @@ export function Sidebar({
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      <div className="space-y-5 px-5 pb-5 pt-6">
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-1">
-            <div className="text-xs font-medium uppercase tracking-[0.3em] text-muted-foreground">
-              Workspace
+      <div className="space-y-4 px-4 pb-4 pt-5">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-foreground text-background">
+              <span className="text-sm font-bold">M</span>
             </div>
-            <div className="text-2xl font-semibold tracking-tight text-gradient">Matrix</div>
+            <div>
+              <div className="text-sm font-semibold tracking-tight">Matrix</div>
+              <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+                Workspace
+              </div>
+            </div>
           </div>
-          <Badge
-            variant={connectionStatus === "connected" ? "default" : "secondary"}
-            className="rounded-full px-3 py-1"
-          >
-            {connectionStatus}
-          </Badge>
+          <div
+            className={cn(
+              "size-2 rounded-full",
+              connectionStatus === "connected" ? "bg-success" : "bg-muted-foreground/40",
+            )}
+            title={connectionStatus}
+          />
         </div>
 
-        {sessions.length > 5 ? (
+        {sessions.length > 5 && (
           <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/50" />
             <Input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
               placeholder="Search sessions"
-              className="pl-9"
+              className="h-8 rounded-lg border-border/50 bg-background pl-8 text-sm"
             />
           </div>
-        ) : null}
+        )}
       </div>
 
-      <ScrollArea className="min-h-0 flex-1 px-3">
-        <div className="space-y-1 pb-4">
+      <ScrollArea className="min-h-0 flex-1 px-2">
+        <div className="space-y-0.5 pb-4">
           {filteredSessions.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-sidebar-border bg-background/60 px-4 py-6 text-center">
-              <FolderSearch2 className="mx-auto mb-3 size-5 text-muted-foreground" />
-              <p className="text-sm font-medium">No sessions found</p>
-              <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                Create a new session or adjust the search filter.
+            <div className="px-3 py-8 text-center">
+              <p className="text-sm text-muted-foreground">No sessions</p>
+              <p className="mt-1 text-xs text-muted-foreground/60">
+                Create one to get started.
               </p>
             </div>
           ) : (
@@ -132,26 +136,21 @@ export function Sidebar({
         </div>
       </ScrollArea>
 
-      <div className="space-y-4 border-t border-sidebar-border px-5 py-5">
+      <div className="space-y-3 border-t border-sidebar-border px-4 py-4">
         <Button
-          className="w-full justify-start rounded-xl"
+          className="w-full justify-center gap-2 rounded-xl text-sm"
           onClick={() => setShowCreateForm((current) => !current)}
           variant={showCreateForm ? "secondary" : "default"}
+          size="sm"
         >
           <Plus className="size-4" />
           New Session
         </Button>
 
-        {showCreateForm ? (
-          <div className="space-y-3 rounded-2xl border border-sidebar-border bg-background/70 p-3">
-            <div className="space-y-1">
-              <p className="text-sm font-medium">Launch a fresh agent session</p>
-              <p className="text-xs leading-5 text-muted-foreground">
-                Sessions appear immediately in the sidebar and auto-open after creation.
-              </p>
-            </div>
+        {showCreateForm && (
+          <div className="space-y-2.5 rounded-xl border border-border/60 bg-background p-3">
             <Select value={selectedAgent} onValueChange={setSelectedAgent}>
-              <SelectTrigger className="w-full">
+              <SelectTrigger className="h-8 w-full rounded-lg text-sm">
                 <SelectValue placeholder="Choose an agent" />
               </SelectTrigger>
               <SelectContent>
@@ -166,23 +165,18 @@ export function Sidebar({
               value={cwd}
               onChange={(event) => setCwd(event.target.value)}
               placeholder="Working directory"
+              className="h-8 rounded-lg text-sm"
             />
             <Button
-              className="w-full"
+              className="w-full rounded-lg"
+              size="sm"
               disabled={creating || !selectedAgent || !cwd.trim()}
               onClick={handleCreate}
             >
-              {creating ? "Creating..." : "Create Session"}
+              {creating ? "Creating..." : "Create"}
             </Button>
           </div>
-        ) : null}
-
-        <Separator />
-
-        <div className="flex items-center gap-2 text-xs leading-5 text-muted-foreground">
-          <Sparkles className="size-4 text-primary" />
-          Responsive sidebar on desktop, drawer navigation on mobile.
-        </div>
+        )}
       </div>
     </div>
   );

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -4,64 +4,69 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.55 0.22 275);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.97 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.003 264.542);
-  --accent-foreground: oklch(0.21 0.006 285.885);
+  --background: oklch(0.975 0.005 75);
+  --foreground: oklch(0.18 0.02 50);
+  --card: oklch(0.99 0.003 75);
+  --card-foreground: oklch(0.18 0.02 50);
+  --popover: oklch(0.99 0.003 75);
+  --popover-foreground: oklch(0.18 0.02 50);
+  --primary: oklch(0.42 0.06 45);
+  --primary-foreground: oklch(0.98 0.005 75);
+  --secondary: oklch(0.955 0.008 75);
+  --secondary-foreground: oklch(0.28 0.02 50);
+  --muted: oklch(0.945 0.008 75);
+  --muted-foreground: oklch(0.50 0.02 50);
+  --accent: oklch(0.94 0.01 75);
+  --accent-foreground: oklch(0.28 0.02 50);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.55 0.22 275);
+  --border: oklch(0.90 0.01 75);
+  --input: oklch(0.92 0.008 75);
+  --ring: oklch(0.50 0.06 45);
   --success: oklch(0.72 0.17 149);
   --success-foreground: oklch(0.18 0.03 149);
   --warning: oklch(0.83 0.15 84);
   --warning-foreground: oklch(0.28 0.04 58);
   --radius: 0.75rem;
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, monospace;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-border: oklch(0.92 0.004 286.32);
+  --font-sans: "Source Sans 3", "Noto Sans SC", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "Berkeley Mono", "JetBrains Mono", ui-monospace, monospace;
+  --font-serif: "Newsreader", "Noto Serif SC", Georgia, serif;
+  --sidebar: oklch(0.97 0.005 75);
+  --sidebar-foreground: oklch(0.18 0.02 50);
+  --sidebar-border: oklch(0.90 0.01 75);
+  --user-bubble: oklch(0.22 0.015 50);
+  --user-bubble-foreground: oklch(0.92 0.008 75);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.67 0.19 275);
-  --primary-foreground: oklch(0.145 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.14 0.01 50);
+  --foreground: oklch(0.92 0.008 75);
+  --card: oklch(0.18 0.01 50);
+  --card-foreground: oklch(0.92 0.008 75);
+  --popover: oklch(0.18 0.01 50);
+  --popover-foreground: oklch(0.92 0.008 75);
+  --primary: oklch(0.72 0.08 45);
+  --primary-foreground: oklch(0.14 0.01 50);
+  --secondary: oklch(0.22 0.01 50);
+  --secondary-foreground: oklch(0.92 0.008 75);
+  --muted: oklch(0.22 0.01 50);
+  --muted-foreground: oklch(0.62 0.015 50);
+  --accent: oklch(0.22 0.01 50);
+  --accent-foreground: oklch(0.92 0.008 75);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.67 0.19 275);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.72 0.08 45);
   --success: oklch(0.76 0.16 149);
   --success-foreground: oklch(0.19 0.04 149);
   --warning: oklch(0.86 0.16 84);
   --warning-foreground: oklch(0.22 0.03 58);
-  --sidebar: oklch(0.18 0.005 285.823);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar: oklch(0.16 0.01 50);
+  --sidebar-foreground: oklch(0.92 0.008 75);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --user-bubble: oklch(0.30 0.015 50);
+  --user-bubble-foreground: oklch(0.92 0.008 75);
 }
 
 @theme inline {
@@ -91,8 +96,11 @@
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-border: var(--sidebar-border);
+  --color-user-bubble: var(--user-bubble);
+  --color-user-bubble-foreground: var(--user-bubble-foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -113,6 +121,8 @@
   html {
     font-family: var(--font-sans);
     color-scheme: light;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   html.dark {
@@ -133,7 +143,7 @@
 
 @layer utilities {
   .text-gradient {
-    background-image: linear-gradient(135deg, oklch(0.55 0.22 275), oklch(0.64 0.18 220));
+    background-image: linear-gradient(135deg, oklch(0.50 0.08 45), oklch(0.42 0.06 30));
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
@@ -141,17 +151,17 @@
 
   .surface-grid {
     background-image:
-      linear-gradient(to right, color-mix(in oklch, var(--border) 55%, transparent) 1px, transparent 1px),
-      linear-gradient(to bottom, color-mix(in oklch, var(--border) 55%, transparent) 1px, transparent 1px);
+      linear-gradient(to right, color-mix(in oklch, var(--border) 40%, transparent) 1px, transparent 1px),
+      linear-gradient(to bottom, color-mix(in oklch, var(--border) 40%, transparent) 1px, transparent 1px);
     background-size: 28px 28px;
   }
 }
 
+/* Status bar working animation */
 @keyframes status-flow {
   0% {
     background-position: -200% 0;
   }
-
   100% {
     background-position: 200% 0;
   }
@@ -162,15 +172,40 @@
     linear-gradient(
       90deg,
       transparent 0%,
-      color-mix(in oklch, var(--primary) 70%, transparent) 35%,
+      color-mix(in oklch, var(--primary) 60%, transparent) 35%,
       var(--primary) 50%,
-      color-mix(in oklch, var(--primary) 70%, transparent) 65%,
+      color-mix(in oklch, var(--primary) 60%, transparent) 65%,
       transparent 100%
     );
   background-size: 200% 100%;
   animation: status-flow 2s ease-in-out infinite;
 }
 
+/* Thinking dots animation */
+@keyframes thinking-bounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+
+.thinking-dot {
+  animation: thinking-bounce 1.4s ease-in-out infinite;
+}
+
+.thinking-dot:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.thinking-dot:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+/* Markdown content styling */
 .markdown-content {
   color: inherit;
 }
@@ -189,7 +224,25 @@
 .markdown-content blockquote,
 .markdown-content pre,
 .markdown-content table {
-  margin: 0.75rem 0;
+  margin: 0.65rem 0;
+}
+
+.markdown-content ul {
+  list-style-type: disc;
+  padding-left: 1.5em;
+}
+
+.markdown-content ol {
+  list-style-type: decimal;
+  padding-left: 1.5em;
+}
+
+.markdown-content li {
+  margin: 0.25rem 0;
+}
+
+.markdown-content strong {
+  font-weight: 650;
 }
 
 .markdown-content code {
@@ -197,18 +250,22 @@
 }
 
 .markdown-content :not(pre) > code {
-  padding: 0.1rem 0.35rem;
+  padding: 0.15rem 0.45rem;
   border-radius: 0.375rem;
-  background: color-mix(in oklch, var(--muted) 85%, transparent);
-  font-size: 0.9em;
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+  font-size: 0.85em;
+  font-weight: 500;
+  letter-spacing: -0.01em;
 }
 
 .markdown-content pre {
   overflow-x: auto;
   border: 1px solid var(--border);
-  border-radius: calc(var(--radius) - 0.125rem);
-  background: color-mix(in oklch, var(--card) 82%, black 18%);
+  border-radius: calc(var(--radius));
+  background: color-mix(in oklch, var(--foreground) 4%, var(--background));
   padding: 0.875rem 1rem;
+  font-size: 0.825rem;
+  line-height: 1.6;
 }
 
 .dark .markdown-content pre {
@@ -216,20 +273,28 @@
 }
 
 .markdown-content blockquote {
-  border-left: 3px solid color-mix(in oklch, var(--primary) 45%, var(--border));
+  border-left: 2px solid color-mix(in oklch, var(--primary) 40%, var(--border));
   padding-left: 1rem;
   color: var(--muted-foreground);
+  font-style: italic;
 }
 
 .markdown-content a {
   color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+
+.markdown-content a:hover {
+  text-decoration-thickness: 2px;
 }
 
 .markdown-content table {
   width: 100%;
   border-collapse: collapse;
   overflow: hidden;
-  border-radius: calc(var(--radius) - 0.125rem);
+  border-radius: calc(var(--radius));
   border: 1px solid var(--border);
 }
 
@@ -245,9 +310,10 @@
   font-weight: 600;
 }
 
+/* Diff viewer */
 .diff-viewer {
   border: 1px solid var(--border);
-  border-radius: calc(var(--radius) - 0.125rem);
+  border-radius: calc(var(--radius));
   overflow: auto;
   font-family: var(--font-mono);
   font-size: 0.75rem;
@@ -260,16 +326,51 @@
 }
 
 .diff-line--added {
-  background: color-mix(in oklch, var(--success) 18%, transparent);
-  color: color-mix(in oklch, var(--success-foreground) 75%, var(--success));
+  background: color-mix(in oklch, var(--success) 14%, transparent);
+  color: color-mix(in oklch, var(--success-foreground) 72%, var(--success));
 }
 
 .diff-line--removed {
-  background: color-mix(in oklch, var(--destructive) 14%, transparent);
-  color: color-mix(in oklch, var(--destructive-foreground) 72%, var(--destructive));
+  background: color-mix(in oklch, var(--destructive) 10%, transparent);
+  color: color-mix(in oklch, var(--destructive-foreground) 68%, var(--destructive));
 }
 
 .diff-line--header {
-  background: color-mix(in oklch, var(--muted) 60%, transparent);
+  background: color-mix(in oklch, var(--muted) 50%, transparent);
   color: var(--muted-foreground);
+}
+
+/* Smooth scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--foreground) 15%, transparent);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--foreground) 25%, transparent);
+}
+
+/* Message entrance animation */
+@keyframes message-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-message-in {
+  animation: message-in 0.3s ease-out;
 }


### PR DESCRIPTION
## Summary
- Replaces generic purple shadcn defaults with a warm cream/parchment color palette inspired by Claude.ai's conversation interface
- Redesigns message bubbles (dark user bubbles, borderless assistant text), input area (card with agent badge), and sidebar (branded logo, simplified items)
- Adds collapsible tool call clusters, message entrance animations, thinking dots, and custom scrollbar

## Screenshots

Before: Generic shadcn purple theme with bordered message cards
After: Warm editorial aesthetic with cream background, dark user bubbles, clean assistant text, refined input area

## Test plan
- [ ] Verify light mode warm color palette renders correctly
- [ ] Verify dark mode warm tones
- [ ] Test message bubbles: user (dark, right-aligned) and assistant (borderless, left)
- [ ] Test tool call collapsible clusters expand/collapse
- [ ] Test input area with agent badge, send button, keyboard shortcuts
- [ ] Test sidebar session list, create form, delete confirmation
- [ ] Test mobile responsive layout (sheet drawer, compact header)
- [ ] Verify Chinese text renders with Noto Sans SC fallback
- [ ] Check markdown rendering (code blocks, lists, tables, blockquotes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)