### PR TITLE
🛡️ Sentinel: Mask auth token in server logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Masking sensitive tokens in logs
+**Vulnerability:** Exposed sensitive authentication tokens in server console logs.
+**Learning:** Printing full authentication tokens to the console (including connection URIs) is a common pattern for local development but poses a security risk if logs are captured or viewed by unauthorized parties.
+**Prevention:** Use the `maskToken` utility in `packages/server/src/auth/token.ts` to obfuscate tokens for safe logging, keeping only the first and last 4 characters.

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateToken, validateToken } from "../auth/token.js";
+import { generateToken, validateToken, maskToken } from "../auth/token.js";
 
 describe("auth/token", () => {
   it("generates a token string", () => {
@@ -16,5 +16,21 @@ describe("auth/token", () => {
   it("rejects an incorrect token", () => {
     const token = generateToken();
     expect(validateToken("wrong-token", token)).toBe(false);
+  });
+
+  describe("maskToken", () => {
+    it("masks a long token", () => {
+      const token = "1234567890abcdefghijklmnopqrstuvwxyz";
+      expect(maskToken(token)).toBe("1234...wxyz");
+    });
+
+    it("masks a short token", () => {
+      const token = "12345678";
+      expect(maskToken(token)).toBe("****");
+    });
+
+    it("masks an empty token", () => {
+      expect(maskToken("")).toBe("****");
+    });
   });
 });

--- a/packages/server/src/auth/token.ts
+++ b/packages/server/src/auth/token.ts
@@ -11,3 +11,13 @@ export function validateToken(provided: string, expected: string): boolean {
   const b = Buffer.from(expected);
   return timingSafeEqual(a, b);
 }
+
+/**
+ * Obfuscates a token for safe logging, keeping only the first and last 4 characters.
+ */
+export function maskToken(token: string): string {
+  if (token.length <= 8) {
+    return "****";
+  }
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import path from "node:path";
 import { loadConfig } from "./config.js";
-import { generateToken } from "./auth/token.js";
+import { generateToken, maskToken } from "./auth/token.js";
 import { getPersistedToken } from "./persistent-config.js";
 import { authMiddleware } from "./auth/middleware.js";
 import { AgentManager } from "./agent-manager/index.js";
@@ -417,10 +417,11 @@ const idleSuspendSweepTimer = setInterval(() => {
 idleSuspendSweepTimer.unref();
 
 console.log(`\n  Matrix Server running on http://${config.host}:${config.port}`);
-console.log(`\n  Auth token: ${serverToken}`);
+console.log(`\n  Auth token: ${maskToken(serverToken)}`);
 const advertisedHost = config.host === "0.0.0.0" ? "127.0.0.1" : config.host;
 const connectionUri = buildConnectionUri(`http://${advertisedHost}:${config.port}`, serverToken);
-console.log(`\n  Connect URI: ${connectionUri}`);
+const maskedConnectionUri = buildConnectionUri(`http://${advertisedHost}:${config.port}`, maskToken(serverToken));
+console.log(`\n  Connect URI: ${maskedConnectionUri}`);
 console.log("\n  Scan QR:");
 qrcode.generate(connectionUri, { small: true });
 console.log(`\n  Discovered agents: ${discoveredAgents.map((a) => a.name).join(", ")}\n`);


### PR DESCRIPTION
🛡️ Sentinel security enhancement: Mask the server authentication token in console logs to prevent exposure of sensitive credentials. Added a `maskToken` utility and corresponding unit tests.

---
*PR created automatically by Jules for task [13707463321676726523](https://jules.google.com/task/13707463321676726523) started by @broven*