### PR TITLE
fix: Mac app crash on launch due to premature window access

### DIFF
--- a/packages/client/src-tauri/src/lib.rs
+++ b/packages/client/src-tauri/src/lib.rs
@@ -34,14 +34,16 @@ pub fn run() {
         updater::install_update,
     ]);
 
-    let mut app = builder
-        .build(tauri::generate_context!())
-        .expect("error while building Matrix client");
-
     #[cfg(desktop)]
-    initialize_desktop_runtime(&mut app).expect("error while initializing Matrix client");
+    let builder = builder.setup(|app| {
+        initialize_desktop_runtime(app)?;
+        Ok(())
+    });
 
-    app.run(|_, _| {});
+    builder
+        .build(tauri::generate_context!())
+        .expect("error while building Matrix client")
+        .run(|_, _| {});
 }
 
 #[cfg(desktop)]


### PR DESCRIPTION
## Summary
- Mac app (.app bundle) crashes immediately on launch with `unwrap()` on `None` at `lib.rs:176`
- Root cause: `initialize_desktop_runtime()` was called between `builder.build()` and `app.run()`, but Tauri 2 creates windows from config only during `app.run()` (on `RuntimeRunEvent::Ready`), so `get_webview_window("main")` returned `None`
- Fix: move desktop initialization into a `.setup()` callback, which runs at the correct lifecycle point — after windows are created

## Test plan
- [x] Debug build launches without crash
- [x] Release build launches without crash
- [x] Sidecar server starts and discovers agents
- [x] Window loads and redirects to localhost:19880

Generated with [Claude Code](https://claude.com/claude-code)