### PR TITLE
feat: validate branch and directory conflicts before worktree creation

### DIFF
--- a/packages/server/src/__tests__/api-rest.test.ts
+++ b/packages/server/src/__tests__/api-rest.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import { createRestRoutes } from "../api/rest/index.js";
 import { AgentManager } from "../agent-manager/index.js";
@@ -8,6 +8,7 @@ import { WorktreeManager } from "../worktree-manager/index.js";
 import { CloneManager } from "../clone-manager/index.js";
 import { ConnectionManager } from "../api/ws/connection-manager.js";
 import { unlinkSync, mkdirSync, rmSync } from "node:fs";
+import { $ } from "bun";
 
 const DB_PATH = "/tmp/matrix-rest-test.db";
 
@@ -143,6 +144,154 @@ describe("REST API", () => {
         body: JSON.stringify({}),
       });
       expect(res.status).toBe(400);
+    });
+  });
+
+  // ── Worktree Creation Validation ────────────────────────────────
+
+  describe("POST /repositories/:repoId/worktrees validation", () => {
+    const REPO_PATH = "/tmp/matrix-test-repo-worktree";
+
+    function buildAppWithWorktreeManager(wm: Partial<WorktreeManager>) {
+      const agentManager = new AgentManager();
+      agentManager.register({ id: "test-agent", name: "Test Agent", command: "echo", args: [] });
+      const s = new Store(DB_PATH);
+      const sm = new SessionManager();
+      const cm = new ConnectionManager();
+      const a = new Hono();
+      a.route("/", createRestRoutes({
+        agentManager,
+        store: s,
+        sessionManager: sm,
+        worktreeManager: wm as WorktreeManager,
+        cloneManager: new CloneManager(),
+        connectionManager: cm,
+        createSessionForWorktree: async () => ({ sessionId: "sess_wt_test", modes: { currentModeId: "code", availableModes: [] } }),
+      }));
+      return { app: a, store: s };
+    }
+
+    beforeEach(async () => {
+      // Create a real git repo so git show-ref commands work
+      rmSync(REPO_PATH, { recursive: true, force: true });
+      mkdirSync(REPO_PATH, { recursive: true });
+      await $`git init ${REPO_PATH}`.quiet();
+      await $`git -C ${REPO_PATH} commit --allow-empty -m "init"`.quiet();
+    });
+
+    afterEach(() => {
+      rmSync(REPO_PATH, { recursive: true, force: true });
+    });
+
+    it("returns 404 when repository does not exist", async () => {
+      const { app: a, store: s } = buildAppWithWorktreeManager({});
+      try {
+        const res = await a.request("/repositories/nonexistent/worktrees", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ branch: "new-branch", baseBranch: "main" }),
+        });
+        expect(res.status).toBe(404);
+      } finally {
+        s.close();
+      }
+    });
+
+    it("returns 400 when branch name is missing", async () => {
+      const { app: a, store: s } = buildAppWithWorktreeManager({});
+      try {
+        const repo = s.createRepository("test-repo", REPO_PATH, {});
+        const res = await a.request(`/repositories/${repo.id}/worktrees`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ baseBranch: "main" }),
+        });
+        expect(res.status).toBe(400);
+      } finally {
+        s.close();
+      }
+    });
+
+    it("returns 400 when branch name is invalid", async () => {
+      const { app: a, store: s } = buildAppWithWorktreeManager({});
+      try {
+        const repo = s.createRepository("test-repo", REPO_PATH, {});
+        const res = await a.request(`/repositories/${repo.id}/worktrees`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ branch: "bad..name", baseBranch: "main" }),
+        });
+        expect(res.status).toBe(400);
+      } finally {
+        s.close();
+      }
+    });
+
+    it("returns 409 when branch already exists locally", async () => {
+      // Create the branch in the real git repo
+      await $`git -C ${REPO_PATH} checkout -b existing-branch`.quiet();
+      await $`git -C ${REPO_PATH} checkout -`.quiet();
+
+      const { app: a, store: s } = buildAppWithWorktreeManager({});
+      try {
+        const repo = s.createRepository("test-repo", REPO_PATH, {});
+        const res = await a.request(`/repositories/${repo.id}/worktrees`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ branch: "existing-branch", baseBranch: "main" }),
+        });
+        expect(res.status).toBe(409);
+        const body = await res.json() as { error: string };
+        expect(body.error).toContain("existing-branch");
+        expect(body.error).toContain("already exists");
+      } finally {
+        s.close();
+      }
+    });
+
+    it("returns 409 when worktree directory already exists on disk", async () => {
+      const candidatePath = "/tmp/matrix-test-repo-worktree-my-feature";
+      mkdirSync(candidatePath, { recursive: true });
+      try {
+        const { app: a, store: s } = buildAppWithWorktreeManager({});
+        try {
+          const repo = s.createRepository("test-repo", REPO_PATH, {});
+          const res = await a.request(`/repositories/${repo.id}/worktrees`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ branch: "my-feature", baseBranch: "main" }),
+          });
+          expect(res.status).toBe(409);
+          const body = await res.json() as { error: string };
+          expect(body.error).toContain("my-feature");
+          expect(body.error).toContain("already exists");
+        } finally {
+          s.close();
+        }
+      } finally {
+        rmSync(candidatePath, { recursive: true, force: true });
+      }
+    });
+
+    it("returns 201 when branch and directory are both free", async () => {
+      const mockWm = {
+        createWorktree: vi.fn().mockResolvedValue("/tmp/matrix-test-repo-worktree-fresh"),
+        listWorktrees: vi.fn().mockResolvedValue([]),
+        removeWorktree: vi.fn().mockResolvedValue(undefined),
+      };
+      const { app: a, store: s } = buildAppWithWorktreeManager(mockWm);
+      try {
+        const repo = s.createRepository("test-repo", REPO_PATH, {});
+        const res = await a.request(`/repositories/${repo.id}/worktrees`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ branch: "fresh-branch", baseBranch: "main" }),
+        });
+        expect(res.status).toBe(201);
+        expect(mockWm.createWorktree).toHaveBeenCalledWith(REPO_PATH, "fresh-branch", "main");
+      } finally {
+        s.close();
+      }
     });
   });
 });

--- a/packages/server/src/__tests__/api-rest.test.ts
+++ b/packages/server/src/__tests__/api-rest.test.ts
@@ -176,7 +176,7 @@ describe("REST API", () => {
       rmSync(REPO_PATH, { recursive: true, force: true });
       mkdirSync(REPO_PATH, { recursive: true });
       await $`git init ${REPO_PATH}`.quiet();
-      await $`git -C ${REPO_PATH} commit --allow-empty -m "init"`.quiet();
+      await $`git -C ${REPO_PATH} -c user.email="test@test.com" -c user.name="Test" commit --allow-empty -m "init"`.quiet();
     });
 
     afterEach(() => {

--- a/packages/server/src/api/rest/repositories.ts
+++ b/packages/server/src/api/rest/repositories.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
+import fs from "node:fs";
+import path from "node:path";
+import { $ } from "bun";
 import type { Store } from "../../store/index.js";
 import type { SessionManager } from "../../session-manager/index.js";
 import type { WorktreeManager } from "../../worktree-manager/index.js";
@@ -152,6 +155,19 @@ export function repositoryRoutes(deps: RepositoryRouteDeps) {
     const invalidBranchPattern = /[\x00-\x1f\x7f ~^:?*\[\\]|\.{2}|@\{|\/\/|\.$|\.lock$|^\/|\/$/;
     if (invalidBranchPattern.test(body.branch) || body.branch.startsWith("-")) {
       return c.json({ error: "Invalid git branch name" }, 400);
+    }
+
+    // Check if branch already exists locally
+    const refCheck = await $`git -C ${repo.path} show-ref --verify refs/heads/${body.branch}`.quiet().nothrow();
+    if (refCheck.exitCode === 0) {
+      return c.json({ error: `Branch '${body.branch}' already exists. Please choose a different name.` }, 409);
+    }
+
+    // Check if worktree directory would collide with an existing path
+    const safeBranch = body.branch.replace(/\//g, "-");
+    const candidatePath = path.join(path.dirname(repo.path), `${path.basename(repo.path)}-${safeBranch}`);
+    if (fs.existsSync(candidatePath)) {
+      return c.json({ error: `Directory for worktree '${body.branch}' already exists. Please choose a different name.` }, 409);
     }
 
     let worktreePath: string | null = null;


### PR DESCRIPTION
## Summary
- Returns 409 with a clear message when the requested branch already exists locally, prompting the user to pick a different name
- Returns 409 with a clear message when the computed worktree directory path already exists on disk
- Adds unit tests covering all validation cases (404, 400 format, 409 branch conflict, 409 dir conflict, 201 happy path)

## Test plan
- [x] `bun test packages/server` — 161 tests pass
- [x] 409 branch conflict: creates a local git branch, verifies the endpoint returns 409 with the branch name in the error message
- [x] 409 directory conflict: creates the candidate directory, verifies 409 with meaningful error
- [x] 201 happy path: mocks `worktreeManager.createWorktree`, verifies creation proceeds

Generated with [Claude Code](https://claude.com/claude-code)