### PR TITLE
🛡️ Sentinel: [HIGH] Prevent Localhost CSRF/DNS Rebinding and mask tokens in logs

### DIFF
--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateToken, validateToken } from "../auth/token.js";
+import { generateToken, validateToken, maskToken } from "../auth/token.js";
 
 describe("auth/token", () => {
   it("generates a token string", () => {
@@ -16,5 +16,21 @@ describe("auth/token", () => {
   it("rejects an incorrect token", () => {
     const token = generateToken();
     expect(validateToken("wrong-token", token)).toBe(false);
+  });
+
+  describe("maskToken", () => {
+    it("masks a long token", () => {
+      const token = "1234567890abcdef1234567890abcdef";
+      expect(maskToken(token)).toBe("1234...cdef");
+    });
+
+    it("masks a short token completely", () => {
+      expect(maskToken("1234567890")).toBe("********");
+    });
+
+    it("handles null/undefined", () => {
+      expect(maskToken(null)).toBe("null");
+      expect(maskToken(undefined)).toBe("undefined");
+    });
   });
 });

--- a/packages/server/src/auth/token.ts
+++ b/packages/server/src/auth/token.ts
@@ -11,3 +11,13 @@ export function validateToken(provided: string, expected: string): boolean {
   const b = Buffer.from(expected);
   return timingSafeEqual(a, b);
 }
+
+/**
+ * Mask a token for safe logging (e.g., "abcd...wxyz").
+ * Returns original string if null/undefined or too short.
+ */
+export function maskToken(token: string | null | undefined): string {
+  if (!token) return String(token);
+  if (token.length < 12) return "********";
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import path from "node:path";
 import { loadConfig } from "./config.js";
-import { generateToken } from "./auth/token.js";
+import { generateToken, maskToken } from "./auth/token.js";
 import { getPersistedToken } from "./persistent-config.js";
 import { authMiddleware } from "./auth/middleware.js";
 import { AgentManager } from "./agent-manager/index.js";
@@ -375,8 +375,13 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 
 const app = new Hono();
 
-// CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+// CORS for web client — allow any origin since access is gated by bearer token.
+// Use an explicit whitelist for allowHeaders to exclude 'X-Matrix-Internal'
+// and prevent malicious websites from bypassing loopback security checks.
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Content-Type", "Authorization"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,10 +400,15 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLoopbackIp = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  if (!isLoopbackIp) return false;
+
+  // Localhost CSRF / DNS Rebinding protection: require a custom non-standard header.
+  // This header is excluded from CORS 'allowHeaders' to ensure browser preflight failure.
+  return c.req.header("X-Matrix-Internal") === "true";
 }
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing
@@ -576,7 +586,7 @@ const idleSuspendSweepTimer = setInterval(() => {
 }, IDLE_SUSPEND_SWEEP_INTERVAL_MS);
 idleSuspendSweepTimer.unref();
 
-log.info({ host: config.host, port: config.port }, "Matrix Server started");
+log.info({ host: config.host, port: config.port, token: maskToken(serverToken) }, "Matrix Server started");
 const advertisedHost = config.host === "0.0.0.0" ? "127.0.0.1" : config.host;
 const connectionUri = buildConnectionUri(`http://${advertisedHost}:${config.port}`, serverToken);
 log.info({ agents: discoveredAgents.map(a => a.name) }, "discovered agents");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive loopback-only endpoints were vulnerable to Localhost CSRF and DNS Rebinding. Additionally, the server's authentication token was logged in plain text during startup.
🎯 Impact: A malicious website visited by a user could steal the Matrix server's authentication token and gain control over the AI agents. Plain text tokens in logs could lead to credential exposure.
🔧 Fix:
- Updated `isLoopbackRequest` to require a custom `X-Matrix-Internal: true` header.
- Hardened CORS configuration by explicitly whitelisting safe headers and excluding the internal header, triggering browser preflight failure for cross-origin attacks.
- Implemented and applied `maskToken` to obfuscate the server token in structured logs.
✅ Verification:
- Added unit tests for `maskToken` in `packages/server/src/__tests__/auth.test.ts`.
- Verified that existing authentication and REST API tests pass.
- Confirmed the build (`tsc --noEmit`) passes.

---
*PR created automatically by Jules for task [3023437354873267760](https://jules.google.com/task/3023437354873267760) started by @broven*