### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF and improve token logging safety

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Localhost CSRF & DNS Rebinding Protection
+**Vulnerability:** Malicious websites can use a user's browser to make requests to services running on `localhost` (Localhost CSRF) or use DNS Rebinding to bypass the Same-Origin Policy.
+**Learning:** Simply checking the remote IP for `127.0.0.1` is insufficient protection because browsers can be coerced into making these requests.
+**Prevention:** Require a custom, non-standard header (e.g., `X-Matrix-Internal: true`) for sensitive loopback endpoints. Ensure this header is NOT in the CORS `allowHeaders` whitelist to guarantee that browser preflight requests (OPTIONS) fail for cross-origin attempts.

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -17,4 +17,23 @@ describe("auth/token", () => {
     const token = generateToken();
     expect(validateToken("wrong-token", token)).toBe(false);
   });
+
+  describe("maskToken", () => {
+    it("masks a long token", async () => {
+      const { maskToken } = await import("../auth/token.js");
+      const token = "1234567890abcdef";
+      expect(maskToken(token)).toBe("1234...cdef");
+    });
+
+    it("masks a short token completely", async () => {
+      const { maskToken } = await import("../auth/token.js");
+      expect(maskToken("12345678")).toBe("****");
+    });
+
+    it("handles null/undefined", async () => {
+      const { maskToken } = await import("../auth/token.js");
+      expect(maskToken(null)).toBe("none");
+      expect(maskToken(undefined)).toBe("none");
+    });
+  });
 });

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { isLoopbackRequest } from "../index.js";
+
+describe("isLoopbackRequest", () => {
+  it("rejects requests missing X-Matrix-Internal header", () => {
+    const mockContext = {
+      req: {
+        header: (name: string) => (name === "X-Matrix-Internal" ? undefined : "127.0.0.1"),
+      },
+      env: {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+          },
+        },
+      },
+    };
+    expect(isLoopbackRequest(mockContext as any)).toBe(false);
+  });
+
+  it("rejects requests with wrong X-Matrix-Internal header value", () => {
+    const mockContext = {
+      req: {
+        header: (name: string) => (name === "X-Matrix-Internal" ? "false" : "127.0.0.1"),
+      },
+      env: {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+          },
+        },
+      },
+    };
+    expect(isLoopbackRequest(mockContext as any)).toBe(false);
+  });
+
+  it("accepts loopback requests with correct X-Matrix-Internal header", () => {
+    const mockContext = {
+      req: {
+        header: (name: string) => (name === "X-Matrix-Internal" ? "true" : "127.0.0.1"),
+      },
+      env: {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+          },
+        },
+      },
+    };
+    expect(isLoopbackRequest(mockContext as any)).toBe(true);
+  });
+
+  it("rejects non-loopback requests even with X-Matrix-Internal header", () => {
+    const mockContext = {
+      req: {
+        header: (name: string) => (name === "X-Matrix-Internal" ? "true" : "192.168.1.1"),
+      },
+      env: {
+        incoming: {
+          socket: {
+            remoteAddress: "192.168.1.1",
+          },
+        },
+      },
+    };
+    expect(isLoopbackRequest(mockContext as any)).toBe(false);
+  });
+});

--- a/packages/server/src/auth/token.ts
+++ b/packages/server/src/auth/token.ts
@@ -11,3 +11,9 @@ export function validateToken(provided: string, expected: string): boolean {
   const b = Buffer.from(expected);
   return timingSafeEqual(a, b);
 }
+
+export function maskToken(token: string | null | undefined): string {
+  if (!token) return "none";
+  if (token.length <= 8) return "****";
+  return `${token.slice(0, 4)}...${token.slice(-4)}`;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import path from "node:path";
 import { loadConfig } from "./config.js";
-import { generateToken } from "./auth/token.js";
+import { generateToken, maskToken } from "./auth/token.js";
 import { getPersistedToken } from "./persistent-config.js";
 import { authMiddleware } from "./auth/middleware.js";
 import { AgentManager } from "./agent-manager/index.js";
@@ -375,8 +375,12 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 
 const app = new Hono();
 
-// CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+// CORS for web client — allow any origin since access is gated by bearer token.
+// Explicitly whitelist allowHeaders to prevent X-Matrix-Internal from being sent by browsers.
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Content-Type", "Authorization"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,7 +399,10 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
+  // Check for X-Matrix-Internal header to prevent Localhost CSRF/DNS Rebinding
+  if (c.req.header("X-Matrix-Internal") !== "true") return false;
+
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
@@ -576,7 +583,7 @@ const idleSuspendSweepTimer = setInterval(() => {
 }, IDLE_SUSPEND_SWEEP_INTERVAL_MS);
 idleSuspendSweepTimer.unref();
 
-log.info({ host: config.host, port: config.port }, "Matrix Server started");
+log.info({ host: config.host, port: config.port, token: maskToken(serverToken) }, "Matrix Server started");
 const advertisedHost = config.host === "0.0.0.0" ? "127.0.0.1" : config.host;
 const connectionUri = buildConnectionUri(`http://${advertisedHost}:${config.port}`, serverToken);
 log.info({ agents: discoveredAgents.map(a => a.name) }, "discovered agents");


### PR DESCRIPTION
This PR addresses two security concerns: potential leakage of authentication tokens in structured logs and vulnerability to Localhost CSRF and DNS Rebinding attacks. By requiring a custom header for loopback-only endpoints and ensuring it cannot be sent via CORS-enabled browsers, we provide robust protection for sensitive local data. Additionally, masking tokens in logs follows best practices for secret management.

---
*PR created automatically by Jules for task [15822978382801790075](https://jules.google.com/task/15822978382801790075) started by @broven*