### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF vulnerability on sensitive endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Localhost CSRF / DNS Rebinding Protection
+**Vulnerability:** Malicious websites could use a user's browser to make cross-origin requests to sensitive loopback-only endpoints (e.g., `/api/auth-info`, `/api/local-ip`) and steal the server's authentication token.
+**Learning:** Standard IP-based loopback checks are insufficient for browser-based attacks because the browser itself is on the loopback network. DNS Rebinding or simple cross-origin requests (if CORS is permissive) can bypass these checks.
+**Prevention:** Require a custom non-standard header (e.g., `X-Matrix-Internal: true`) for sensitive loopback endpoints. Ensure this header is EXCLUDED from the CORS `allowHeaders` whitelist so that browsers will block cross-origin requests during the preflight (OPTIONS) phase.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { isLoopbackRequest } from "../index.js";
+
+describe("Loopback Security", () => {
+  let app: Hono;
+  const serverToken = "test-token";
+
+  beforeEach(() => {
+    app = new Hono();
+
+    // Exact same CORS config as in index.ts
+    app.use(
+      "/*",
+      cors({
+        origin: (origin) => origin || "*",
+        allowHeaders: ["Content-Type", "Authorization"],
+      }),
+    );
+
+    app.get("/api/auth-info", (c) => {
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: serverToken });
+    });
+  });
+
+  it("rejects loopback request without X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {}, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("accepts loopback request with X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe(serverToken);
+  });
+
+  it("rejects non-loopback request even with X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "1.2.3.4" } }
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("CORS does not allow X-Matrix-Internal header", async () => {
+    // Preflight request
+    const res = await app.request("/api/auth-info", {
+      method: "OPTIONS",
+      headers: {
+        "Origin": "https://malicious.com",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "X-Matrix-Internal"
+      }
+    });
+
+    // If it's NOT in allowHeaders, the browser should block the actual request
+    // Hono's cors middleware returns 204 or 200 for OPTIONS
+    // We check if the response header Access-Control-Allow-Headers includes X-Matrix-Internal
+    const allowedHeaders = res.headers.get("Access-Control-Allow-Headers");
+    if (allowedHeaders) {
+      const headersArray = allowedHeaders.split(",").map(h => h.trim().toLowerCase());
+      expect(headersArray).not.toContain("x-matrix-internal");
+    }
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -375,8 +375,16 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 
 const app = new Hono();
 
-// CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+// CORS for web client — allow any origin since access is gated by bearer token.
+// We use an explicit allowHeaders whitelist to exclude X-Matrix-Internal,
+// which prevents malicious websites from bypassing loopback security checks.
+app.use(
+  "/*",
+  cors({
+    origin: (origin) => origin || "*",
+    allowHeaders: ["Content-Type", "Authorization"],
+  }),
+);
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,10 +403,12 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLoopback = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isInternal = c.req.header("X-Matrix-Internal") === "true";
+  return isLoopback && isInternal;
 }
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing


### PR DESCRIPTION
🛡️ Sentinel has identified and fixed a high-priority security vulnerability where sensitive loopback-only endpoints like `/api/auth-info` (which provides the master authentication token) were vulnerable to Localhost CSRF or DNS Rebinding attacks from malicious websites.

The fix involves requiring a custom non-standard header (`X-Matrix-Internal: true`) for these endpoints and explicitly excluding this header from the CORS `allowHeaders` whitelist. This ensures that browsers will fail the CORS preflight (OPTIONS) check for any cross-origin request from a malicious website, preventing them from reading the sensitive authentication token.

Changes:
- **Server:** Updated `isLoopbackRequest` logic in `packages/server/src/index.ts` and hardened CORS configuration.
- **Client:** Integrated the required header into all legitimate client-side fetch calls to these endpoints.
- **Verification:** Added a comprehensive regression test suite in `packages/server/src/__tests__/security-loopback.test.ts`.
- **Documentation:** Recorded the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1729847810352022628](https://jules.google.com/task/1729847810352022628) started by @broven*