### PR TITLE
🛡️ Sentinel: Fix Localhost CSRF and Information Disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-31 - Localhost CSRF and Information Disclosure
+**Vulnerability:** Sensitive loopback endpoints (`/api/auth-info`, `/api/local-ip`) were accessible to cross-origin browser requests from any origin when the server was running on localhost. This allowed malicious websites visited by the user to steal the server's authentication token and LAN IP.
+**Learning:** Checking for loopback IP addresses (`127.0.0.1`, `::1`) is insufficient for protecting local servers from malicious websites. Browsers allow cross-origin GET requests to localhost by default, and these requests appear to come from the loopback interface.
+**Prevention:** Require a custom non-standard header (e.g., `X-Matrix-Internal: true`) for all sensitive loopback-only endpoints. Additionally, ensure the CORS configuration uses an explicit `allowHeaders` whitelist that *excludes* this custom header, forcing a preflight failure for cross-origin browser requests.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { isLoopbackRequest } from "../index.js";
+
+describe("Security: Loopback Protection", () => {
+  it("rejects request without X-Matrix-Internal header even on loopback", async () => {
+    const app = new Hono();
+    app.get("/test", (c) => {
+      if (!isLoopbackRequest(c)) return c.json({ error: "Forbidden" }, 403);
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/test", {}, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("accepts request with X-Matrix-Internal header on loopback", async () => {
+    const app = new Hono();
+    app.get("/test", (c) => {
+      if (!isLoopbackRequest(c)) return c.json({ error: "Forbidden" }, 403);
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/test", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("rejects request with X-Matrix-Internal header NOT on loopback", async () => {
+    const app = new Hono();
+    app.get("/test", (c) => {
+      if (!isLoopbackRequest(c)) return c.json({ error: "Forbidden" }, 403);
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/test", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "1.2.3.4" } }
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -375,8 +375,12 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 
 const app = new Hono();
 
-// CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+// CORS for web client — allow any origin since access is gated by bearer token.
+// Use an explicit whitelist for allowHeaders to exclude X-Matrix-Internal and prevent CSRF.
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Content-Type", "Authorization"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,7 +399,11 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
+  // Require custom header to prevent cross-origin browser access even when on loopback
+  if (c.req.header("X-Matrix-Internal") !== "true") {
+    return false;
+  }
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";


### PR DESCRIPTION
Hardened sensitive loopback endpoints by requiring a custom header and restricting CORS headers. This prevents malicious websites from stealing the server's auth token via cross-origin requests to localhost.

---
*PR created automatically by Jules for task [17700014314310532884](https://jules.google.com/task/17700014314310532884) started by @broven*