### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF/DNS Rebinding on sensitive endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - [Localhost CSRF / DNS Rebinding Mitigation]
+**Vulnerability:** Malicious websites could use a user's browser to make requests to sensitive endpoints on `localhost` (e.g., `/api/auth-info`) and steal authentication tokens because the server had a permissive CORS policy (`origin: "*"`) and only protected these endpoints with a loopback IP check.
+**Learning:** Relying solely on IP-based authentication for local services is insufficient in a web context. A custom non-standard header (`X-Matrix-Internal: true`) should be required for sensitive loopback-only endpoints to force a CORS preflight and prevent unauthorized access from untrusted origins.
+**Prevention:** Always require a custom header for sensitive local-only endpoints and ensure that this header is explicitly included in the CORS `allowHeaders` list to maintain authorized access while blocking malicious cross-origin requests.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+// @ts-ignore - we will export this and implement the logic in the next step
+import { isLoopbackRequest } from "../index.js";
+
+describe("isLoopbackRequest security", () => {
+  it("requires both loopback IP and X-Matrix-Internal header", async () => {
+    const app = new Hono();
+    app.get("/test", (c) => {
+      if (isLoopbackRequest(c)) {
+        return c.json({ ok: true });
+      }
+      return c.json({ error: "Forbidden" }, 403);
+    });
+
+    // Case 1: Loopback IP, but NO header (Vulnerable state)
+    const res1 = await app.request("/test", {}, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res1.status).toBe(403);
+
+    // Case 2: Loopback IP AND correct header (Secure state)
+    const res2 = await app.request("/test", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res2.status).toBe(200);
+
+    // Case 3: Non-loopback IP, even with header (Still forbidden)
+    const res3 = await app.request("/test", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "1.2.3.4" } }
+    } as any);
+    expect(res3.status).toBe(403);
+
+    // Case 4: Non-loopback IP, no header
+    const res4 = await app.request("/test", {}, {
+      incoming: { socket: { remoteAddress: "1.2.3.4" } }
+    } as any);
+    expect(res4.status).toBe(403);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -375,8 +375,12 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 
 const app = new Hono();
 
-// CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+// CORS for web client — allow any origin since access is gated by bearer token.
+// Whitelist X-Matrix-Internal so the browser can send it for loopback endpoints.
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,7 +399,11 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
+  // Check for custom header to protect against DNS rebinding/localhost CSRF
+  if (c.req.header("X-Matrix-Internal") !== "true") {
+    return false;
+  }
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";


### PR DESCRIPTION
I have implemented a security enhancement to protect sensitive local server endpoints from Localhost CSRF and DNS Rebinding attacks. By requiring a custom `X-Matrix-Internal: true` header for endpoints like `/api/auth-info`, we ensure that only authorized clients (like our own app or a trusted local environment) can access them, even if the request comes from the local machine's IP. 

Key changes include server-side validation logic, CORS policy updates, and client-side integration across the React application. A new regression test verifies that requests without the header are properly rejected.

---
*PR created automatically by Jules for task [15683548134363942018](https://jules.google.com/task/15683548134363942018) started by @broven*