### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF and DNS Rebinding on loopback endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+# Sentinel Journal
+
+## 2025-05-15 - Localhost CSRF & DNS Rebinding Protection
+**Vulnerability:** Sensitive loopback-only endpoints (`/api/auth-info`, `/api/local-ip`) were accessible to any browser-based origin due to permissive global CORS settings (`origin: "*"`) and lack of origin verification.
+**Learning:** Even if an endpoint is restricted to loopback IPs, a browser on the same machine can be tricked by a malicious website (Cross-Origin) to fetch data from `localhost`. Simply checking the remote IP is insufficient because the browser's request *comes* from the local machine.
+**Prevention:**
+1. Require a custom non-standard header (e.g., `X-Matrix-Internal: true`). This forces a CORS preflight (`OPTIONS` request), which browsers will block if the server doesn't explicitly allow the requesting origin.
+2. Implement server-side `Origin` header validation against a trusted local allowlist (e.g., `http://localhost:`, `http://127.0.0.1:`) to prevent malicious sites from bypassing security if CORS is misconfigured or if DNS rebinding is attempted.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+import { isLoopbackRequest } from "../index.js";
+
+describe("Loopback CSRF Security", () => {
+  let app: Hono;
+  const serverToken = "test-token";
+
+  beforeEach(() => {
+    app = new Hono();
+    // Replicate the fixed server setup
+    app.use("/*", cors({
+      origin: (origin) => origin || "*",
+      allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+    }));
+
+    const localOriginPrefixes = ["http://localhost:", "http://127.0.0.1:", "http://[::1]:"];
+    const originCheckMiddleware = async (c: any, next: any) => {
+      const origin = c.req.header("Origin");
+      if (origin && !localOriginPrefixes.some(p => origin.startsWith(p))) {
+        return c.json({ error: "Forbidden Origin" }, 403);
+      }
+      await next();
+    };
+    app.use("/api/auth-info", originCheckMiddleware);
+
+    app.get("/api/auth-info", (c) => {
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: serverToken });
+    });
+  });
+
+  it("FIXED: /api/auth-info rejects malicious Origin", async () => {
+    // We simulate a request from a malicious site
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "Origin": "https://malicious.com",
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+    const body = await res.json() as any;
+    expect(body.error).toBe("Forbidden Origin");
+  });
+
+  it("FIXED: /api/auth-info rejects missing X-Matrix-Internal header", async () => {
+     const res = await app.request("/api/auth-info", {
+      headers: {
+        "Origin": "http://localhost:3000",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+    expect(res.status).toBe(403);
+  });
+
+  it("isLoopbackRequest correctly identifies 127.0.0.1 with header", async () => {
+     const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+     }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+    expect(res.status).toBe(200);
+  });
+
+  it("isLoopbackRequest correctly identifies ::1 with header", async () => {
+     const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+     }, {
+      incoming: {
+        socket: {
+          remoteAddress: "::1",
+        },
+      },
+    } as any);
+    expect(res.status).toBe(200);
+  });
+
+  it("isLoopbackRequest rejects external IP", async () => {
+     const res = await app.request("/api/auth-info", {}, {
+      incoming: {
+        socket: {
+          remoteAddress: "1.2.3.4",
+        },
+      },
+    } as any);
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -376,7 +376,22 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+}));
+
+// Specialized CORS/Origin check for loopback-only endpoints to prevent Localhost CSRF
+const localOriginPrefixes = ["http://localhost:", "http://127.0.0.1:", "http://[::1]:"];
+const originCheckMiddleware = async (c: any, next: any) => {
+  const origin = c.req.header("Origin");
+  if (origin && !localOriginPrefixes.some(p => origin.startsWith(p))) {
+    return c.json({ error: "Forbidden Origin" }, 403);
+  }
+  await next();
+};
+app.use("/api/auth-info", originCheckMiddleware);
+app.use("/api/local-ip", originCheckMiddleware);
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,10 +410,12 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
+  const isInternal = c.req.header("X-Matrix-Internal") === "true";
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLocal = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  return isLocal && isInternal;
 }
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive loopback-only endpoints (/api/auth-info, /api/local-ip) were vulnerable to Cross-Origin access from malicious websites and DNS Rebinding. Permissive CORS allowed any origin to read the server's auth token if the request originated from the local machine.
🎯 Impact: A malicious website could steal the Matrix server's authentication token, granting full control over the AI agent system.
🔧 Fix: 
- Modified isLoopbackRequest to require a custom X-Matrix-Internal: true header, forcing a CORS preflight.
- Added originCheckMiddleware to validate the Origin header against a trusted local allowlist (localhost, 127.0.0.1).
- Updated all client-side fetch calls to include the required header.
✅ Verification: Added regression tests in packages/server/src/__tests__/security-loopback.test.ts verifying that malicious origins and missing headers are rejected. Verified that legitimate local requests with the correct header are still permitted.

---
*PR created automatically by Jules for task [4100058022229688176](https://jules.google.com/task/4100058022229688176) started by @broven*