### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF and DNS Rebinding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - Localhost CSRF / DNS Rebinding on Sensitive Endpoints
+**Vulnerability:** Endpoints that are only protected by a loopback IP check (127.0.0.1) can be accessed by malicious websites via the user's browser. This allows an attacker to steal sensitive information like authentication tokens (via `/api/auth-info`) or network details.
+**Learning:** Browser security models allow any website to make requests to `localhost`. While CORS usually prevents reading the response, it doesn't prevent the request itself (CSRF), and DNS rebinding can even bypass the Origin check if only the IP is validated.
+**Prevention:**
+1. Require a custom non-standard header (e.g., `X-Matrix-Internal: true`) for all sensitive loopback-only endpoints. This forces a CORS preflight and prevents simple CSRF.
+2. Explicitly validate the `Origin` header against a whitelist of local origins (`localhost`, `127.0.0.1`) if it's present.
+3. Combine these with the existing remote address IP check for defense in depth.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,11 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,11 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: {
+              "X-Matrix-Internal": "true",
+            },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,11 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: {
+          "X-Matrix-Internal": "true",
+        },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,11 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: {
+                        "X-Matrix-Internal": "true",
+                      },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+// Use the actual implementation from index.ts
+import { isLoopbackRequest } from "../index.js";
+
+describe("Security: Localhost CSRF / DNS Rebinding", () => {
+  let app: Hono;
+  const serverToken = "secret-token";
+
+  beforeEach(() => {
+    app = new Hono();
+
+    // Updated CORS setup
+    app.use("/*", cors({
+      origin: (origin) => origin || "*",
+      allowHeaders: ["X-Matrix-Internal", "Content-Type", "Authorization"],
+    }));
+
+    // Updated endpoint using the fixed isLoopbackRequest
+    app.get("/api/auth-info", (c) => {
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: serverToken });
+    });
+  });
+
+  it("FIXED: blocks cross-origin requests from malicious sites", async () => {
+    // Simulate a request from a malicious website
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "Origin": "http://malicious.com",
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("FIXED: blocks requests without X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {}, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("ALLOWED: allows requests from local origin with X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "Origin": "http://localhost:3000",
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe(serverToken);
+  });
+
+  it("ALLOWED: allows non-browser requests (no Origin) with X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe(serverToken);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -376,7 +376,10 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["X-Matrix-Internal", "Content-Type", "Authorization"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,10 +398,28 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+
+  const isLoopbackIp = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  if (!isLoopbackIp) return false;
+
+  // DNS Rebinding / CSRF Protection for sensitive loopback endpoints:
+  // 1. Require a custom header that cannot be sent cross-origin without a preflight.
+  if (c.req.header("X-Matrix-Internal") !== "true") return false;
+
+  // 2. If an Origin header is present, ensure it's from a trusted local source.
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isLocalOrigin =
+      origin.startsWith("http://localhost:") ||
+      origin.startsWith("http://127.0.0.1:") ||
+      origin.startsWith("http://[::1]:");
+    if (!isLocalOrigin) return false;
+  }
+
+  return true;
 }
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Sensitive loopback-only endpoints (/api/auth-info, /api/local-ip) were only protected by an IP check, making them vulnerable to Localhost CSRF and DNS Rebinding. A malicious website could steal the server's authentication token.
🎯 Impact: Full compromise of the Matrix server if a user visits a malicious website while the server is running on their local machine.
🔧 Fix:
- Introduced X-Matrix-Internal: true header requirement for sensitive loopback endpoints to force CORS preflight.
- Added explicit Origin header validation against local allowlist.
- Updated all client-side fetch calls to include the new header.
- Updated server CORS configuration to allow the new header.
✅ Verification: Added packages/server/src/__tests__/security-loopback.test.ts which reproduces the vulnerability and verifies the fix. Ran existing auth and REST tests to ensure no regressions.

---
*PR created automatically by Jules for task [8785439593808169396](https://jules.google.com/task/8785439593808169396) started by @broven*