### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF and token leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+## 2025-05-22 - Localhost CSRF and Token Leakage
+**Vulnerability:** Sensitive loopback-only endpoints (`/api/auth-info`, `/api/local-ip`) were vulnerable to cross-origin access from malicious websites via the browser due to a wildcard CORS policy and lack of origin validation.
+**Learning:** Even endpoints restricted to loopback IPs can be accessed by a browser via CSRF or simple cross-origin requests if CORS is not strictly configured. A wildcard CORS policy (`*`) allows any site to read the response if the user visits it while the server is running.
+**Prevention:** Use a two-layered defense for sensitive local endpoints:
+1. Require a custom non-standard header (e.g., `X-Matrix-Internal: true`) to force a CORS preflight and block simple requests.
+2. Explicitly validate the `Origin` header on the server to ensure it matches a trusted local source (localhost, 127.0.0.1, or the app's custom protocol).

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { localOriginMiddleware, isLoopbackRequest } from "../index.js";
+
+describe("Security: Loopback Endpoints", () => {
+  let app: Hono;
+  const mockToken = "test-token";
+
+  beforeAll(() => {
+    app = new Hono();
+    app.use(
+      "/*",
+      cors({
+        origin: (origin) => origin || "*",
+        allowHeaders: ["Content-Type", "Authorization", "X-Matrix-Internal"],
+      })
+    );
+
+    app.get("/api/auth-info", localOriginMiddleware, (c) => {
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: mockToken });
+    });
+  });
+
+  it("allows request with loopback IP and X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.token).toBe(mockToken);
+  });
+
+  it("rejects request missing X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {}, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects request from non-loopback IP even with header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "192.168.1.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects request with untrusted Origin header", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "http://malicious.com",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(403);
+    const data = await res.json() as any;
+    expect(data.error).toBe("Forbidden cross-origin request");
+  });
+
+  it("allows request with trusted Origin header (localhost)", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "http://localhost:5173",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("allows request with trusted Origin header (tauri)", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "tauri://localhost",
+      },
+    }, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1",
+        },
+      },
+    } as any);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
 import { cors } from "hono/cors";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
@@ -376,7 +377,13 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use(
+  "/*",
+  cors({
+    origin: (origin) => origin || "*",
+    allowHeaders: ["Content-Type", "Authorization", "X-Matrix-Internal"],
+  }),
+);
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,11 +402,35 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
+  const isInternal = c.req.header("X-Matrix-Internal") === "true";
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLoopback =
+    addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  return isInternal && isLoopback;
 }
+
+/**
+ * Middleware to protect loopback-only endpoints from cross-origin browser requests.
+ * Blocks if Origin is present but doesn't match a trusted local source.
+ */
+export const localOriginMiddleware = createMiddleware(async (c, next) => {
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isLocal =
+      origin.startsWith("http://localhost:") ||
+      origin.startsWith("http://127.0.0.1:") ||
+      origin.startsWith("http://[::1]:") ||
+      origin.startsWith("tauri://");
+
+    if (!isLocal) {
+      log.warn({ origin, path: c.req.path }, "Blocked cross-origin loopback request");
+      return c.json({ error: "Forbidden cross-origin request" }, 403);
+    }
+  }
+  await next();
+});
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing
 app.get("/api/ping", authMiddleware(serverToken), (c) => {
@@ -407,7 +438,7 @@ app.get("/api/ping", authMiddleware(serverToken), (c) => {
 });
 
 // Auth info endpoint — loopback only, lets desktop app fetch its token
-app.get("/api/auth-info", (c) => {
+app.get("/api/auth-info", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }
@@ -415,7 +446,7 @@ app.get("/api/auth-info", (c) => {
 });
 
 // Local IP endpoint — loopback only, for sidecar QR code generation
-app.get("/api/local-ip", (c) => {
+app.get("/api/local-ip", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Localhost CSRF and Token Leakage. Sensitive loopback-only endpoints (`/api/auth-info`, `/api/local-ip`) were vulnerable to cross-origin access from malicious websites via the browser due to a wildcard CORS policy and lack of origin validation.
🎯 **Impact**: A malicious website visited by the user could steal the Matrix `serverToken`, granting it full control over the server and the ability to execute arbitrary commands on the user's machine via spawned ACP agents.
🔧 **Fix**: Implemented a defense-in-depth approach:
1. Updated `isLoopbackRequest` to strictly require the `X-Matrix-Internal: true` header, forcing a CORS preflight in browsers.
2. Added `localOriginMiddleware` to validate that the `Origin` header (if present) matches a trusted local source (`localhost`, `127.0.0.1`, or `tauri://`).
3. Whitelisted the new header in the server's CORS configuration.
4. Updated all client-side fetch calls in `packages/client` to include the required header.
✅ **Verification**: 
- Created a new test suite `packages/server/src/__tests__/security-loopback.test.ts` that specifically verifies these protections against various attack vectors (missing header, untrusted origin, non-loopback IP).
- Verified that all existing tests in `packages/client`, `packages/sdk`, and `packages/server` continue to pass or are unaffected by the change.

---
*PR created automatically by Jules for task [15572361204504874048](https://jules.google.com/task/15572361204504874048) started by @broven*