### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF / DNS Rebinding on sensitive endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Localhost CSRF & DNS Rebinding Protection
+**Vulnerability:** Malicious websites can potentially access sensitive loopback-only endpoints (like `/api/auth-info`) if the server only checks the remote IP address. An attacker can use DNS Rebinding to make a browser think a malicious domain is 127.0.0.1, or use simple CSRF if no custom headers are required.
+**Learning:** IP-based loopback restrictions (127.0.0.1) are insufficient against DNS Rebinding. Browsers do not protect "localhost" from other origins unless specific security measures are in place. Requiring a non-standard custom header (e.g., `X-Matrix-Internal`) forces a CORS preflight, and validating the `Origin` header against a trusted local list (localhost, tauri://, etc.) provides defense-in-depth.
+**Prevention:** Always require a custom header and validate the `Origin` header for sensitive endpoints that are restricted to loopback access.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, describe } from "bun:test";
+import { isLoopbackRequest, localOriginMiddleware } from "../index.js";
+
+describe("isLoopbackRequest", () => {
+  test("identifies 127.0.0.1 as loopback only if internal header is present", () => {
+    const c_with_header = {
+      env: { incoming: { socket: { remoteAddress: "127.0.0.1" } } },
+      req: { header: (n: string) => n === "X-Matrix-Internal" ? "true" : undefined }
+    };
+    expect(isLoopbackRequest(c_with_header)).toBe(true);
+
+    const c_without_header = {
+      env: { incoming: { socket: { remoteAddress: "127.0.0.1" } } },
+      req: { header: () => undefined }
+    };
+    expect(isLoopbackRequest(c_without_header)).toBe(false);
+  });
+
+  test("identifies ::1 as loopback only if internal header is present", () => {
+    const c = {
+      env: { incoming: { socket: { remoteAddress: "::1" } } },
+      req: { header: (n: string) => n === "X-Matrix-Internal" ? "true" : undefined }
+    };
+    expect(isLoopbackRequest(c)).toBe(true);
+  });
+
+  test("identifies ::ffff:127.0.0.1 as loopback only if internal header is present", () => {
+    const c = {
+      env: { incoming: { socket: { remoteAddress: "::ffff:127.0.0.1" } } },
+      req: { header: (n: string) => n === "X-Matrix-Internal" ? "true" : undefined }
+    };
+    expect(isLoopbackRequest(c)).toBe(true);
+  });
+
+  test("identifies 192.168.1.1 as NOT loopback even with header", () => {
+    const c = {
+      env: { incoming: { socket: { remoteAddress: "192.168.1.1" } } },
+      req: { header: (n: string) => n === "X-Matrix-Internal" ? "true" : undefined }
+    };
+    expect(isLoopbackRequest(c)).toBe(false);
+  });
+});
+
+describe("localOriginMiddleware", () => {
+  test("allows trusted origins", async () => {
+    const trusted = ["http://localhost:5173", "http://127.0.0.1:8080", "http://[::1]:3000", "tauri://localhost"];
+    for (const origin of trusted) {
+      let nextCalled = false;
+      const c = {
+        req: {
+          header: (n: string) => n === "Origin" ? origin : undefined,
+          path: "/api/auth-info"
+        },
+        json: () => { throw new Error("Should not return error for trusted origin"); }
+      };
+      await localOriginMiddleware(c, async () => { nextCalled = true; });
+      expect(nextCalled).toBe(true);
+    }
+  });
+
+  test("blocks untrusted origins", async () => {
+    const untrusted = ["http://malicious.com", "https://evil.org", "http://localhost.evil.com"];
+    for (const origin of untrusted) {
+      let nextCalled = false;
+      let responseStatus = 0;
+      const c = {
+        req: {
+          header: (n: string) => n === "Origin" ? origin : undefined,
+          path: "/api/auth-info"
+        },
+        json: (data: any, status: number) => {
+          responseStatus = status;
+          return { data, status };
+        }
+      };
+      await localOriginMiddleware(c, async () => { nextCalled = true; });
+      expect(nextCalled).toBe(false);
+      expect(responseStatus).toBe(403);
+    }
+  });
+
+  test("allows requests without Origin header", async () => {
+    let nextCalled = false;
+    const c = {
+      req: {
+        header: () => undefined,
+        path: "/api/auth-info"
+      }
+    };
+    await localOriginMiddleware(c, async () => { nextCalled = true; });
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -376,7 +376,13 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use(
+  "/*",
+  cors({
+    origin: (origin) => origin || "*",
+    allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+  }),
+);
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,11 +401,33 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLoopbackIp = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const hasInternalHeader = c.req.header("X-Matrix-Internal") === "true";
+  return isLoopbackIp && hasInternalHeader;
 }
+
+/**
+ * Middleware to block requests to sensitive loopback endpoints if they come from
+ * an untrusted Origin (e.g. a malicious website trying CSRF or DNS rebinding).
+ */
+export const localOriginMiddleware = async (c: any, next: () => Promise<void>) => {
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isAllowed =
+      origin.startsWith("http://localhost:") ||
+      origin.startsWith("http://127.0.0.1:") ||
+      origin.startsWith("http://[::1]:") ||
+      origin.startsWith("tauri://");
+    if (!isAllowed) {
+      log.warn({ origin, path: c.req.path }, "blocked request from untrusted origin");
+      return c.json({ error: "Forbidden: Invalid Origin" }, 403);
+    }
+  }
+  await next();
+};
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing
 app.get("/api/ping", authMiddleware(serverToken), (c) => {
@@ -407,7 +435,7 @@ app.get("/api/ping", authMiddleware(serverToken), (c) => {
 });
 
 // Auth info endpoint — loopback only, lets desktop app fetch its token
-app.get("/api/auth-info", (c) => {
+app.get("/api/auth-info", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }
@@ -415,7 +443,7 @@ app.get("/api/auth-info", (c) => {
 });
 
 // Local IP endpoint — loopback only, for sidecar QR code generation
-app.get("/api/local-ip", (c) => {
+app.get("/api/local-ip", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }


### PR DESCRIPTION
This PR implements defense-in-depth for sensitive loopback-only endpoints by requiring a custom header and validating the Origin header, effectively mitigating Localhost CSRF and DNS Rebinding attacks.

---
*PR created automatically by Jules for task [8869137785353584612](https://jules.google.com/task/8869137785353584612) started by @broven*