### PR TITLE
🛡️ Sentinel: [HIGH] Fix Localhost CSRF and DNS Rebinding vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-19 - [Localhost CSRF & DNS Rebinding Protection]
+**Vulnerability:** Sensitive loopback-only endpoints (/api/auth-info, /api/local-ip) were accessible to any browser-based cross-origin request if the source IP was 127.0.0.1.
+**Learning:** Checking the remote address alone is insufficient to protect sensitive loopback endpoints in a browser environment. DNS rebinding or simple CSRF can allow a malicious site to make requests that appear to come from the local machine.
+**Prevention:** Require a custom non-standard header (e.g., `X-Matrix-Internal: true`) to force a CORS preflight. Additionally, validate the `Origin` header against a trusted allowlist of local schemes (localhost, tauri://) to provide defense-in-depth.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { isLoopbackRequest, localOriginMiddleware } from "../index.js";
+
+describe("Security: Loopback Endpoints Fix", () => {
+  let app: Hono;
+  const serverToken = "test-token";
+
+  beforeEach(() => {
+    app = new Hono();
+
+    app.get("/api/auth-info", localOriginMiddleware, (c) => {
+      // In tests, we need to pass the token somehow or mock it.
+      // For this test, we just want to verify the middleware and isLoopbackRequest.
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: serverToken });
+    });
+  });
+
+  it("blocks loopback request WITH malicious Origin header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "Origin": "http://evil.com",
+        "X-Matrix-Internal": "true"
+      }
+    });
+
+    const res = await app.request(req, undefined, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1"
+        }
+      }
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json() as any;
+    expect(body.error).toBe("Forbidden: Untrusted Origin");
+  });
+
+  it("blocks loopback request WITHOUT X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+        headers: {
+            "Origin": "http://localhost:5173"
+        }
+    });
+
+    const res = await app.request(req, undefined, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1"
+        }
+      }
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows loopback request with trusted Origin AND X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "Origin": "http://localhost:5173",
+        "X-Matrix-Internal": "true"
+      }
+    });
+
+    const res = await app.request(req, undefined, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1"
+        }
+      }
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.token).toBe(serverToken);
+  });
+
+  it("allows loopback request without Origin header AND with X-Matrix-Internal header (e.g. from curl or local app)", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true"
+      }
+    });
+
+    const res = await app.request(req, undefined, {
+      incoming: {
+        socket: {
+          remoteAddress: "127.0.0.1"
+        }
+      }
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import path from "node:path";
@@ -376,7 +377,10 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use("/*", cors({
+  origin: (origin) => origin || "*",
+  allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+}));
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,11 +399,36 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
   if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const isLoopback = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  if (!isLoopback) return false;
+
+  // Require internal header to prevent CSRF/DNS rebinding from browsers
+  return c.req.header("X-Matrix-Internal") === "true";
 }
+
+/**
+ * Middleware to ensure the Origin header (if present) is from a trusted local source.
+ * This provides defense-in-depth against Localhost CSRF.
+ */
+export const localOriginMiddleware = createMiddleware(async (c, next) => {
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isAllowed =
+      origin.startsWith("http://localhost:") ||
+      origin.startsWith("http://127.0.0.1:") ||
+      origin.startsWith("http://[::1]:") ||
+      origin.startsWith("tauri://");
+
+    if (!isAllowed) {
+      log.warn({ origin }, "blocked request from untrusted origin");
+      return c.json({ error: "Forbidden: Untrusted Origin" }, 403);
+    }
+  }
+  await next();
+});
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing
 app.get("/api/ping", authMiddleware(serverToken), (c) => {
@@ -407,7 +436,7 @@ app.get("/api/ping", authMiddleware(serverToken), (c) => {
 });
 
 // Auth info endpoint — loopback only, lets desktop app fetch its token
-app.get("/api/auth-info", (c) => {
+app.get("/api/auth-info", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }
@@ -415,7 +444,7 @@ app.get("/api/auth-info", (c) => {
 });
 
 // Local IP endpoint — loopback only, for sidecar QR code generation
-app.get("/api/local-ip", (c) => {
+app.get("/api/local-ip", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }


### PR DESCRIPTION
### 🚨 Severity: HIGH
### 💡 Vulnerability: Localhost CSRF and DNS Rebinding
Sensitive loopback-only endpoints (/api/auth-info and /api/local-ip) were previously accessible to any cross-origin request as long as the source IP was 127.0.0.1. This allowed malicious websites to potentially steal the server's authentication token or LAN IP via CSRF or DNS rebinding.

### 🎯 Impact:
An attacker could gain full access to the Matrix server by stealing the auth token via a browser-based attack when the user visits a malicious site.

### 🔧 Fix:
1.  **Custom Header:** Updated `isLoopbackRequest` to require the `X-Matrix-Internal: true` header. Since browsers cannot set custom headers on cross-origin requests without a successful CORS preflight, this blocks simple CSRF and DNS rebinding.
2.  **Origin Validation:** Implemented `localOriginMiddleware` which checks the `Origin` header (if present) and only allows trusted local sources (`localhost`, `127.0.0.1`, `tauri://`).
3.  **Client Update:** Updated all call-sites in `packages/client` to provide the required header.

### ✅ Verification:
- Added `packages/server/src/__tests__/security-loopback.test.ts` which confirms that:
    - Requests with malicious origins are blocked (403).
    - Requests missing the `X-Matrix-Internal` header are blocked (403).
    - Legitimate requests from trusted origins or local apps (no origin) are allowed (200).
- Verified that core REST API tests pass.
- Verified that building internal dependencies (`@matrix/protocol`, `@matrix/sdk`) works and tests pass.

---
*PR created automatically by Jules for task [7301857100314987247](https://jules.google.com/task/7301857100314987247) started by @broven*