### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Localhost CSRF / Token Theft

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Localhost CSRF / Token Theft
+**Vulnerability:** Malicious websites could make cross-origin requests to 'localhost:8080/api/auth-info' to steal the server's authentication token, because the server only checked the remote IP address and had a permissive CORS policy.
+**Learning:** Checking 'remoteAddress' is insufficient to protect local-only endpoints in a browser-accessible server. Cross-origin requests from the same machine also appear to come from '127.0.0.1'.
+**Prevention:** Use a custom non-standard header (e.g., 'X-Matrix-Internal') to force a CORS preflight, and implement a server-side check to validate that the 'Origin' header belongs to a trusted local source.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { localOriginMiddleware, isLoopbackRequest } from "../index.js";
+
+describe("Loopback Security", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+    app.get("/api/auth-info", localOriginMiddleware, (c) => {
+      if (!isLoopbackRequest(c)) {
+        return c.json({ error: "Forbidden" }, 403);
+      }
+      return c.json({ token: "secret-token" });
+    });
+  });
+
+  it("rejects requests from non-loopback IPs", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: { "X-Matrix-Internal": "true" }
+    }, {
+      incoming: { socket: { remoteAddress: "192.168.1.1" } }
+    } as any);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects requests missing X-Matrix-Internal header", async () => {
+    const res = await app.request("/api/auth-info", {}, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects requests with non-local Origin", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "http://malicious.com"
+      }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Non-local origin");
+  });
+
+  it("allows requests from localhost Origin", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "http://localhost:5173"
+      }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBe("secret-token");
+  });
+
+  it("allows requests from tauri:// Origin", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true",
+        "Origin": "tauri://localhost"
+      }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows requests with no Origin (direct client)", async () => {
+    const res = await app.request("/api/auth-info", {
+      headers: {
+        "X-Matrix-Internal": "true"
+      }
+    }, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } }
+    } as any);
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { serve } from "@hono/node-server";
 import path from "node:path";
@@ -376,7 +377,36 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use(
+  "/*",
+  cors({
+    origin: (origin) => origin || "*",
+    allowHeaders: ["X-Matrix-Internal", "Authorization", "Content-Type"],
+  }),
+);
+
+const TRUSTED_LOCAL_ORIGINS = [
+  "http://localhost:",
+  "http://127.0.0.1:",
+  "http://[::1]:",
+  "tauri://",
+];
+
+/**
+ * Middleware to block CSRF/DNS rebinding attacks from non-local origins
+ * when accessing sensitive loopback endpoints.
+ */
+export const localOriginMiddleware = createMiddleware(async (c, next) => {
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isTrusted = TRUSTED_LOCAL_ORIGINS.some((trusted) => origin.startsWith(trusted));
+    if (!isTrusted) {
+      log.warn({ origin }, "Blocked non-local origin request to sensitive endpoint");
+      return c.json({ error: "Forbidden: Non-local origin" }, 403);
+    }
+  }
+  await next();
+});
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,9 +425,10 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
+export function isLoopbackRequest(c: any): boolean {
   const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
-  if (!addr) return false;
+  const isInternal = c.req.header("X-Matrix-Internal") === "true";
+  if (!addr || !isInternal) return false;
   return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
 }
 
@@ -407,7 +438,7 @@ app.get("/api/ping", authMiddleware(serverToken), (c) => {
 });
 
 // Auth info endpoint — loopback only, lets desktop app fetch its token
-app.get("/api/auth-info", (c) => {
+app.get("/api/auth-info", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }
@@ -415,7 +446,7 @@ app.get("/api/auth-info", (c) => {
 });
 
 // Local IP endpoint — loopback only, for sidecar QR code generation
-app.get("/api/local-ip", (c) => {
+app.get("/api/local-ip", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }


### PR DESCRIPTION
I have identified and fixed a critical security vulnerability that allowed malicious websites to steal the Matrix server's authentication token via a Localhost CSRF / DNS Rebinding attack.

### Vulnerability
The server's sensitive loopback endpoints (`/api/auth-info` and `/api/local-ip`) previously only checked the request's `remoteAddress`. Since the server also had a permissive CORS policy (`origin: "*"`), a malicious website visited by the user could make a cross-origin request to these endpoints. Because the request originates from the user's browser on the same machine, the IP check would pass, allowing the attacker to steal the `MATRIX_TOKEN`.

### Fix
1.  **Header Requirement:** Updated `isLoopbackRequest` in `packages/server/src/index.ts` to require a custom `X-Matrix-Internal: true` header. Since this is a non-standard header, browsers will force a CORS preflight (OPTIONS request).
2.  **Origin Validation:** Implemented `localOriginMiddleware` which validates the `Origin` header against a whitelist of trusted local sources (`localhost`, `127.0.0.1`, `[::1]`, `tauri://`). This middleware is applied to the sensitive endpoints.
3.  **CORS Update:** Whitelisted the `X-Matrix-Internal` header in the server's CORS configuration.
4.  **Client Integration:** Updated all fetch calls in the client (`main.tsx`, `useMatrixClient.tsx`, `ConnectPage.tsx`, `ShareServerModal.tsx`) to include the required header.

### Verification
I added a new test file `packages/server/src/__tests__/security-loopback.test.ts` which verifies:
*   Rejection of non-loopback IPs.
*   Rejection when the `X-Matrix-Internal` header is missing.
*   Rejection of unauthorized origins (e.g., `malicious.com`).
*   Successful access for valid local requests.

All security tests passed, and I verified that the project still builds correctly.

---
*PR created automatically by Jules for task [4745969838748099350](https://jules.google.com/task/4745969838748099350) started by @broven*