### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF on loopback endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Localhost CSRF and DNS Rebinding Protection
+**Vulnerability:** Malicious websites could fetch the sensitive server auth token from the loopback-only `/api/auth-info` endpoint because loopback IP checks alone don't prevent browsers from sending cross-origin requests, especially if CORS is overly permissive.
+**Learning:** Defense-in-depth for local sidecar APIs requires both network-level (IP) checks AND application-level (custom header + Origin validation) checks. Requiring a non-standard header (e.g., `X-Matrix-Internal`) forces a CORS preflight, which the server can then reject if the `Origin` is not a trusted local source.
+**Prevention:** Always require a custom non-standard header for sensitive internal endpoints. Implement middleware to validate the `Origin` header against a whitelist of local schemes/hosts (localhost, 127.0.0.1, tauri://) for all loopback-restricted routes.

--- a/packages/client/src/components/ShareServerModal.tsx
+++ b/packages/client/src/components/ShareServerModal.tsx
@@ -56,7 +56,9 @@ export function ShareServerModal({
     let cancelled = false;
 
     // Fetch LAN IP from local server
-    fetch(`${serverUrl}/api/local-ip`)
+    fetch(`${serverUrl}/api/local-ip`, {
+      headers: { "X-Matrix-Internal": "true" },
+    })
       .then((res) => res.json())
       .then((data: { ip?: string }) => {
         if (cancelled) return;

--- a/packages/client/src/hooks/useMatrixClient.tsx
+++ b/packages/client/src/hooks/useMatrixClient.tsx
@@ -115,7 +115,9 @@ export function MatrixClientProvider({ children }: { children: ReactNode }) {
       // Poll until sidecar is ready (up to ~15 seconds)
       for (let i = 0; i < 60 && !cancelled; i++) {
         try {
-          const res = await fetch(`${localServerUrl}/api/auth-info`);
+          const res = await fetch(`${localServerUrl}/api/auth-info`, {
+            headers: { "X-Matrix-Internal": "true" },
+          });
           if (res.ok) {
             const { token } = await res.json() as { token: string };
             if (!cancelled && !connectedRef.current) {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -37,7 +37,9 @@ if (shouldInstallBridge()) {
       }
 
       // Fetch auth token
-      const authRes = await fetch(`${serverUrl}/api/auth-info`);
+      const authRes = await fetch(`${serverUrl}/api/auth-info`, {
+        headers: { "X-Matrix-Internal": "true" },
+      });
       if (!authRes.ok) {
         logger.warn("[bridge-ws] Could not fetch auth-info, skipping bridge WebSocket");
         return;

--- a/packages/client/src/pages/ConnectPage.tsx
+++ b/packages/client/src/pages/ConnectPage.tsx
@@ -154,7 +154,9 @@ export function ConnectPage() {
                 onClick={async () => {
                   // Fetch the real token from the local server
                   try {
-                    const res = await fetch(`${localServerUrl}/api/auth-info`);
+                    const res = await fetch(`${localServerUrl}/api/auth-info`, {
+                      headers: { "X-Matrix-Internal": "true" },
+                    });
                     const { token: realToken } = await res.json() as { token: string };
                     setShareServer({
                       serverUrl: localServerUrl,

--- a/packages/server/src/__tests__/security-loopback.test.ts
+++ b/packages/server/src/__tests__/security-loopback.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { isLoopbackRequest, localOriginMiddleware } from "../auth/security.js";
+
+describe("Security Loopback Protection", () => {
+  const app = new Hono();
+  const serverToken = "secret-token";
+
+  app.use(
+    "/*",
+    cors({
+      origin: (origin) => origin || "*",
+      allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+    }),
+  );
+
+  app.get("/api/auth-info", localOriginMiddleware, (c) => {
+    if (!isLoopbackRequest(c)) {
+      return c.json({ error: "Forbidden" }, 403);
+    }
+    return c.json({ token: serverToken });
+  });
+
+  it("blocks requests without X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info");
+    const res = await app.fetch(req, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } } as any
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("allows loopback requests with X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: { "X-Matrix-Internal": "true" }
+    });
+    const res = await app.fetch(req, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } } as any
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { token: string };
+    expect(body.token).toBe(serverToken);
+  });
+
+  it("blocks requests with malicious Origin header even if X-Matrix-Internal is present", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "Origin": "http://evil.com",
+        "X-Matrix-Internal": "true"
+      }
+    });
+    const res = await app.fetch(req, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } } as any
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain("Invalid Origin");
+  });
+
+  it("allows requests from localhost Origin with X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "Origin": "http://localhost:5173",
+        "X-Matrix-Internal": "true"
+      }
+    });
+    const res = await app.fetch(req, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } } as any
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows requests from tauri Origin with X-Matrix-Internal header", async () => {
+    const req = new Request("http://localhost/api/auth-info", {
+      headers: {
+        "Origin": "tauri://localhost",
+        "X-Matrix-Internal": "true"
+      }
+    });
+    const res = await app.fetch(req, {
+      incoming: { socket: { remoteAddress: "127.0.0.1" } } as any
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/server/src/auth/security.ts
+++ b/packages/server/src/auth/security.ts
@@ -1,0 +1,43 @@
+import { createMiddleware } from "hono/factory";
+import type { Context } from "hono";
+import { logger } from "../logger.js";
+
+const log = logger.child({ target: "security" });
+
+/**
+ * Checks if a request is coming from a loopback address and has the internal header.
+ */
+export function isLoopbackRequest(c: Context): boolean {
+  // @ts-ignore - access to node-specific socket info in Hono/Bun
+  const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
+  if (!addr) return false;
+
+  const isLoopbackIp = addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
+  const hasInternalHeader = c.req.header("X-Matrix-Internal") === "true";
+
+  return isLoopbackIp && hasInternalHeader;
+}
+
+/**
+ * Middleware to protect loopback-only endpoints from CSRF via non-local Origins.
+ * If an Origin header is present, it must be a trusted local source.
+ */
+export const localOriginMiddleware = createMiddleware(async (c, next) => {
+  const origin = c.req.header("Origin");
+  if (origin) {
+    const isLocal =
+      origin === "http://localhost" ||
+      origin.startsWith("http://localhost:") ||
+      origin === "http://127.0.0.1" ||
+      origin.startsWith("http://127.0.0.1:") ||
+      origin === "http://[::1]" ||
+      origin.startsWith("http://[::1]:") ||
+      origin.startsWith("tauri://");
+
+    if (!isLocal) {
+      log.warn({ origin, path: c.req.path }, "rejected non-local origin for loopback endpoint");
+      return c.json({ error: "Forbidden: Invalid Origin for loopback request" }, 403);
+    }
+  }
+  await next();
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "./config.js";
 import { generateToken } from "./auth/token.js";
 import { getPersistedToken } from "./persistent-config.js";
 import { authMiddleware } from "./auth/middleware.js";
+import { isLoopbackRequest, localOriginMiddleware } from "./auth/security.js";
 import { AgentManager } from "./agent-manager/index.js";
 import { discoverAgents } from "./agent-manager/discovery.js";
 import { Store } from "./store/index.js";
@@ -376,7 +377,14 @@ function pushCachedCommands(sessionId: string, worktreeId: string | undefined, a
 const app = new Hono();
 
 // CORS for web client — allow any origin since access is gated by bearer token
-app.use("/*", cors({ origin: (origin) => origin || "*" }));
+app.use(
+  "/*",
+  cors({
+    origin: (origin) => origin || "*",
+    // We allow X-Matrix-Internal for loopback-specific preflights
+    allowHeaders: ["Authorization", "Content-Type", "X-Matrix-Internal"],
+  }),
+);
 
 // Auth middleware for REST (WebSocket handles auth separately)
 app.use("/agents", authMiddleware(serverToken));
@@ -395,11 +403,6 @@ app.use("/agent-profiles", authMiddleware(serverToken));
 app.use("/agent-profiles/*", authMiddleware(serverToken));
 // Note: /bridge/* auth is handled inside setupBridge (WebSocket uses query param auth)
 
-function isLoopbackRequest(c: any): boolean {
-  const addr: string | undefined = c.env?.incoming?.socket?.remoteAddress;
-  if (!addr) return false;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
-}
 
 // Ping endpoint — auth-protected, externally accessible, for connection testing
 app.get("/api/ping", authMiddleware(serverToken), (c) => {
@@ -407,7 +410,7 @@ app.get("/api/ping", authMiddleware(serverToken), (c) => {
 });
 
 // Auth info endpoint — loopback only, lets desktop app fetch its token
-app.get("/api/auth-info", (c) => {
+app.get("/api/auth-info", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }
@@ -415,7 +418,7 @@ app.get("/api/auth-info", (c) => {
 });
 
 // Local IP endpoint — loopback only, for sidecar QR code generation
-app.get("/api/local-ip", (c) => {
+app.get("/api/local-ip", localOriginMiddleware, (c) => {
   if (!isLoopbackRequest(c)) {
     return c.json({ error: "Forbidden" }, 403);
   }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Malicious websites could fetch the sensitive server auth token from loopback-only endpoints (like /api/auth-info) via CSRF or DNS Rebinding attacks. This was possible because loopback IP checks alone don't prevent browser-based cross-origin access if CORS is permissive.
🎯 Impact: An attacker could steal the server's authentication token, granting them full control over the Matrix server and its agents.
🔧 Fix: Implemented a defense-in-depth strategy:
1.  Created `localOriginMiddleware` to validate that the `Origin` header (if present) belongs to a trusted local source (localhost, 127.0.0.1, [::1], or tauri://).
2.  Updated `isLoopbackRequest` to also require a custom `X-Matrix-Internal: true` header. This forces a CORS preflight for browser requests.
3.  Applied these protections to the `/api/auth-info` and `/api/local-ip` endpoints.
4.  Updated all client-side fetch calls to these endpoints to include the required header.
5.  Extracted security logic to a dedicated `auth/security.ts` file for better testability and to avoid side effects.
✅ Verification: Added a new test suite `packages/server/src/__tests__/security-loopback.test.ts` that specifically verifies these protections. All existing E2E and unit tests also pass.

---
*PR created automatically by Jules for task [4710322039631189442](https://jules.google.com/task/4710322039631189442) started by @broven*